### PR TITLE
Fix caching streams and cache lifetimes.

### DIFF
--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -141,6 +141,7 @@ class CacheEntry
         // Stream/Resource can't be serialized... So we copy the content
         if ($this->response !== null) {
             $this->responseBody = (string)$this->response->getBody();
+            $this->response->getBody()->rewind();
         }
 
         return array_keys(get_object_vars($this));

--- a/src/PrivateCache.php
+++ b/src/PrivateCache.php
@@ -98,15 +98,18 @@ class PrivateCache implements CacheStorageInterface
     public function cache(RequestInterface $request, ResponseInterface $response)
     {
         try {
-            $lifeTime = $this->getCacheObject($response)->getStaleAt()->getTimestamp() - time();
-            if($lifeTime > 0) {
-                return $this->storage->save($this->getCacheKey($request), serialize($this->getCacheObject($response)), $lifeTime);
-            }
-            else {
-                return false;
+            $cacheObject = $this->getCacheObject($response);
+            if(isset($cacheObject))
+            {
+                $lifeTime = $this->getCacheObject($response)->getStaleAt()->getTimestamp() - time();
+                if($lifeTime > 0) {
+                    return $this->storage->save($this->getCacheKey($request), serialize($this->getCacheObject($response)), $lifeTime);
+                }
             }
         } catch (\Exception $ignored) {
             return false;
         }
+        
+        return false;
     }
 }

--- a/src/PrivateCache.php
+++ b/src/PrivateCache.php
@@ -98,7 +98,13 @@ class PrivateCache implements CacheStorageInterface
     public function cache(RequestInterface $request, ResponseInterface $response)
     {
         try {
-            return $this->storage->save($this->getCacheKey($request), serialize($this->getCacheObject($response)));
+            $lifeTime = $this->getCacheObject($response)->getStaleAt()->getTimestamp() - time();
+            if($lifeTime > 0) {
+                return $this->storage->save($this->getCacheKey($request), serialize($this->getCacheObject($response)), $lifeTime);
+            }
+            else {
+                return false;
+            }
         } catch (\Exception $ignored) {
             return false;
         }


### PR DESCRIPTION
I found some issues with the way caching is implemented at the moment.

1. Serializing the response stream causes the stream to seek to the end. You need to rewind the stream or the caller code will receive an empty body.
2. All entries are being cached forever. I forwarded a lifetime through Doctrine's Cache interface.