### PR TITLE
Ensure a $cacheEntry can either be a CacheEntry or null

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -142,6 +142,8 @@ class CacheMiddleware
                         );
                     }
                 }
+            }else{
+                $cacheEntry = null;
             }
 
             /** @var Promise $promise */


### PR DESCRIPTION
The Doctrine cache implementation does not return "null" for unsuccessful fetches, but false. That can lead to crashes in `getStaleResponse`.