### PR TITLE
\Closure is too strict as type hint

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -102,11 +102,11 @@ class CacheMiddleware
     }
 
     /**
-     * @param \Closure $handler
+     * @param callable $handler
      *
-     * @return \Closure
+     * @return callable
      */
-    public function __invoke(\Closure $handler)
+    public function __invoke(callable $handler)
     {
         return function (RequestInterface $request, array $options) use (&$handler) {
             if (!isset($this->httpMethods[strtoupper($request->getMethod())])) {


### PR DESCRIPTION
I tried to use your middleware inside an `HandlerStack` and I got a fatal error because CurlMultiHandler is callable but not a closure