### PR TITLE
Update to the Doctrine suggestion message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "suggest": {
     "guzzlehttp/guzzle": "For using this library. It was created for Guzzle6. (but you can use it with any PSR-7 HTTP Client)",
-    "doctrine/cache": "This library have a lot of ready-to-use cache storage (to be use with Kevinrob\\GuzzleCache\\Storage\\DoctrineCacheWrapper)",
+    "doctrine/cache": "This library have a lot of ready-to-use cache storage (to be use with Kevinrob\\GuzzleCache\\Storage\\DoctrineCacheStorage)",
     "league/flysystem": "To be use with Kevinrob\\GuzzleCache\\Storage\\FlysystemStorage"
   }
 }


### PR DESCRIPTION
The suggestion message for Doctrine in composer.json will now correctly mention DoctrineCacheStorage instead of DoctrineCacheWrapper