### PR TITLE
Add GreedyCacheStrategy

### DIFF
--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Kevinrob\GuzzleCache\Strategy;
+
+use Kevinrob\GuzzleCache\CacheEntry;
+use Kevinrob\GuzzleCache\Storage\CacheStorageInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * This strategy represent a "greedy" HTTP client.
+ *
+ * It can be used to cache responses in spite of any cache related response headers,
+ * but it SHOULDN'T be used unless absolutely necessary, e.g. when accessing
+ * badly designed APIs without Cache control.
+ *
+ * Obviously, this follows no RFC :(.
+ */
+class GreedyCacheStrategy extends PrivateCacheStrategy
+{
+    /**
+     * @var int
+     */
+    protected $ttl;
+
+    public function __construct(CacheStorageInterface $cache = null, $ttl)
+    {
+        $this->ttl = $ttl;
+
+        parent::__construct($cache);
+    }
+
+    protected function getCacheKey(RequestInterface $request)
+    {
+        return sha1(
+            'greedy'.$request->getMethod().$request->getUri()
+        );
+    }
+
+    public function cache(RequestInterface $request, ResponseInterface $response)
+    {
+        $warningMessage = sprintf('%d - "%s" "%s"',
+            299,
+            'Cached although the response headers indicate not to do it!',
+            (new \DateTime())->format(\DateTime::RFC1123)
+        );
+
+        $response = $response->withAddedHeader('Warning', $warningMessage);
+
+        if ($cacheObject = $this->getCacheObject($request, $response)) {
+            return $this->storage->save(
+                $this->getCacheKey($request),
+                $cacheObject
+            );
+        }
+
+        return false;
+    }
+
+    protected function getCacheObject(RequestInterface $request, ResponseInterface $response)
+    {
+        if (!array_key_exists($response->getStatusCode(), $this->statusAccepted)) {
+            // Don't cache it
+            return null;
+        }
+
+        return new CacheEntry($request, $response, new \DateTime(sprintf('+%d seconds', $this->ttl)));
+    }
+
+    public function fetch(RequestInterface $request)
+    {
+        return $this->storage->fetch($this->getCacheKey($request));
+    }
+}

--- a/tests/GreedyCacheTest.php
+++ b/tests/GreedyCacheTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Kevinrob\GuzzleCache;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
+use Psr\Http\Message\RequestInterface;
+
+class GreedyCacheTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    protected function setUp()
+    {
+        $stack = HandlerStack::create(function (RequestInterface $request, array $options) {
+            switch ($request->getUri()->getPath()) {
+                case '/vary':
+                    return new FulfilledPromise(
+                        (new Response())
+                            ->withAddedHeader('Vary', '*')
+                    );
+                case '/no-store':
+                    return new FulfilledPromise(
+                        (new Response())
+                            ->withAddedHeader('Cache-Control', 'no-store')
+                    );
+                case '/no-cache':
+                    return new FulfilledPromise(
+                        (new Response())
+                            ->withAddedHeader('Cache-Control', 'no-cache')
+                    );
+                case '/pragma':
+                    return new FulfilledPromise(
+                        (new Response())
+                            ->withAddedHeader('Pragma', 'no-cache')
+                    );
+                case '/partial-content':
+                    return new FulfilledPromise(
+                        (new Response())
+                            ->withStatus(206)
+                    );
+            }
+
+            throw new \InvalidArgumentException();
+        });
+
+        $stack->push(new CacheMiddleware(
+            new GreedyCacheStrategy(null, 10))
+        );
+
+        $this->client = new Client(['handler' => $stack]);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @dataProvider cachableRequestProvider
+     */
+    public function testItIsGreedy(Request $request)
+    {
+        $this->client->send($request); // Will be cached
+        $response = $this->client->send($request); // Will come from cache
+
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+        $this->assertTrue($response->hasHeader('Warning'));
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @dataProvider nonCachableRequestProvider
+     */
+    public function testItIsNotStupid(Request $request)
+    {
+        $this->client->send($request); // Will not be cached
+        $response = $this->client->send($request); // Will not come from cache
+
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+    }
+
+    public function cachableRequestProvider()
+    {
+        return [
+            [new Request('GET', '/vary')],
+            [new Request('GET', '/no-store')],
+            [new Request('GET', '/no-cache')],
+            [new Request('GET', '/pragma')],
+        ];
+    }
+
+    public function nonCachableRequestProvider()
+    {
+        return [
+            [new Request('POST', '/vary')],
+            [new Request('GET', '/partial-content')],
+        ];
+    }
+}


### PR DESCRIPTION
First of all: thank you for this middleware - it's well designed, and it was a pleasure integrating it (and saved me a lot of time) :heart:.

A propos ":heart:": it breaks mine to propose an addition that is not RFC-compliant, but I think it could still be useful for certain edge cases.

In my case, I had to access
- a remote resource which provided no cache control headers
- an unreliable remote resource which would not be accessible from time to time

This is where the Greedy Cache Strategy came to life - it stores responses in the cache for a fixed amount of time, and I use it in a second middleware inside the HandlerStack:

```php
use Doctrine\Common\Cache\ArrayCache;
use Doctrine\Common\Cache\ChainCache;
use Doctrine\Common\Cache\FilesystemCache;
use GuzzleHttp\Client;
use GuzzleHttp\HandlerStack;
use Kevinrob\GuzzleCache\CacheMiddleware;
use Kevinrob\GuzzleCache\Storage\DoctrineCacheStorage;
use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;

$caches = [
    new ArrayCache(),
    new FilesystemCache('/tmp/'),
];

$stack = HandlerStack::create();

// The normal cache
$stack->push(new CacheMiddleware(
    new PrivateCacheStrategy(
        new DoctrineCacheStorage(new ChainCache($caches))
    )
), 'cache');

// Notice the ->before() instead of ->push().
// We want the greedy cache to have a lesser priority
$stack->before('cache', new CacheMiddleware(
    new GreedyCacheStrategy(
        new DoctrineCacheStorage(new ChainCache($caches)), $ttl = 600
    )
), 'greedy-cache');

$client = new Client(['handler' => $stack]);

echo $stack;
```

At least it adds a "Warning" header (see #24) :smile: 

Cheers!
:octocat: Jérôme