### PR TITLE
Keep headers when revalidate cache entry (RFC 7234 - section 4.3.4)

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -198,6 +198,10 @@ class CacheMiddleware
                             ->withStatus($cacheEntry->getResponse()->getStatusCode())
                             ->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_HIT);
                         $response = $response->withBody($cacheEntry->getResponse()->getBody());
+
+                        if ($cacheEntry->getResponse()->getHeader('Link')) {
+                            $response = $response->withHeader('Link', $cacheEntry->getResponse()->getHeader('Link'));
+                        }
                     } else {
                         $response = $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
                     }
@@ -265,6 +269,10 @@ class CacheMiddleware
                         /** @var ResponseInterface $response */
                         $response = $response->withStatus($cacheEntry->getResponse()->getStatusCode());
                         $response = $response->withBody($cacheEntry->getResponse()->getBody());
+
+                        if ($cacheEntry->getResponse()->getHeader('Link')) {
+                            $response = $response->withHeader('Link', $cacheEntry->getResponse()->getHeader('Link'));
+                        }
                     }
 
                     self::addToCache($cacheStorage, $request, $response);

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -199,8 +199,11 @@ class CacheMiddleware
                             ->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_HIT);
                         $response = $response->withBody($cacheEntry->getResponse()->getBody());
 
-                        if ($cacheEntry->getResponse()->getHeader('Link')) {
-                            $response = $response->withHeader('Link', $cacheEntry->getResponse()->getHeader('Link'));
+                        // Merge headers of the "304 Not Modified" and the cache entry
+                        foreach ($cacheEntry->getResponse()->getHeaders() as $headerName => $headerValue) {
+                            if (!$response->getHeader($headerName)) {
+                                $response->withHeader($headerName, $headerValue);
+                            }
                         }
                     } else {
                         $response = $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
@@ -270,8 +273,11 @@ class CacheMiddleware
                         $response = $response->withStatus($cacheEntry->getResponse()->getStatusCode());
                         $response = $response->withBody($cacheEntry->getResponse()->getBody());
 
-                        if ($cacheEntry->getResponse()->getHeader('Link')) {
-                            $response = $response->withHeader('Link', $cacheEntry->getResponse()->getHeader('Link'));
+                        // Merge headers of the "304 Not Modified" and the cache entry
+                        foreach ($cacheEntry->getResponse()->getHeaders() as $headerName => $headerValue) {
+                            if (!$response->getHeader($headerName)) {
+                                $response->withHeader($headerName, $headerValue);
+                            }
                         }
                     }
 


### PR DESCRIPTION
I'm using your middleware to cache the results from the GitHub API. Like many others, GitHub sends its pagination URLs in the Link header, and currently this header gets lost on revalidation.

With this PR, the Link header information is kept in the cache and subsequent HTTP requests won't be lost. Let me know, if you think that there are other infos to be kept also :)

Regards,
Pascal