### PR TITLE
- Switched to using "forever" in Laravel's cache when the lifetime is…

### DIFF
--- a/src/Storage/LaravelCacheStorage.php
+++ b/src/Storage/LaravelCacheStorage.php
@@ -44,7 +44,12 @@ class LaravelCacheStorage implements CacheStorageInterface
     {
         try {
             $lifeTime = $data->getTTL();
-            if ($lifeTime >= 0) {
+            if ($lifeTime === 0) {
+                return $this->cache->forever(
+                    $key, 
+                    serialize($data)
+                );
+            } else if ($lifeTime > 0) {
                 return $this->cache->add(
                     $key,
                     serialize($data),


### PR DESCRIPTION
In Laravel 5.3, the "bug" which made 0 result in caching forever was fixed. This fixes the bug introduced in the library as a result, and conforms to Laravel's desired interface.