### PR TITLE
Fix typos FlysystemStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ $stack->push(
 [...]
 use League\Flysystem\Adapter\Local;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
-use Kevinrob\GuzzleCache\Storage\FilesystemStorage;
+use Kevinrob\GuzzleCache\Storage\FlysystemStorage;
 
 [...]
 
 $stack->push(
   new CacheMiddleware(
     new PrivateCacheStrategy(
-      new FilesystemStorage(
+      new FlysystemStorage(
         new Local('/path/to/cache')
       )
     )


### PR DESCRIPTION
The class `Kevinrob\GuzzleCache\Storage\FilesystemStorage` doesn't exist.
Let's fix it by using `Kevinrob\GuzzleCache\Storage\FlysystemStorage`.