### PR TITLE
Promote $timestampStale to protected

### DIFF
--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -50,7 +50,7 @@ class CacheEntry
      *
      * @var int
      */
-    private $timestampStale;
+    protected $timestampStale;
 
     /**
      * @param RequestInterface $request


### PR DESCRIPTION
Promote `$timestampStale` to protected to avoid serialize() error when `CacheEntry` is extended.