### PR TITLE
Prevent meta-headers from being included in cache

### DIFF
--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -101,6 +101,14 @@ class CacheEntry
     }
 
     /**
+     * @return ResponseInterface
+     */
+    public function getOriginalResponse()
+    {
+        return $this->response;
+    }
+
+    /**
      * @return RequestInterface
      */
     public function getOriginalRequest()

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -202,8 +202,8 @@ class CacheMiddleware
                         $response = $response->withBody($cacheEntry->getResponse()->getBody());
 
                         // Merge headers of the "304 Not Modified" and the cache entry
-                        foreach ($cacheEntry->getResponse()->getHeaders() as $headerName => $headerValue) {
-                            if (!$response->hasHeader($headerName)) {
+                        foreach ($cacheEntry->getOriginalResponse()->getHeaders() as $headerName => $headerValue) {
+                            if (!$response->hasHeader($headerName) and $headerName !== self::HEADER_CACHE_INFO) {
                                 $response = $response->withHeader($headerName, $headerValue);
                             }
                         }


### PR DESCRIPTION
When issuing a revalidate request and getting back a 304, the resulting cached response should not include HTTP response headers that were automatically generated by the cache application, i.e. the Age and X-Kevinrob-Cache headers.