### PR TITLE
LaravelCacheStorage: Fix cache age calculation

### DIFF
--- a/src/Storage/LaravelCacheStorage.php
+++ b/src/Storage/LaravelCacheStorage.php
@@ -43,7 +43,8 @@ class LaravelCacheStorage implements CacheStorageInterface
     public function save($key, CacheEntry $data)
     {
         try {
-            $lifeTime = $data->getTTL();
+            // getTTL returns minutes, Laravel needs seconds
+            $lifeTime = $data->getTTL() / 60;
             if ($lifeTime === 0) {
                 return $this->cache->forever(
                     $key, 


### PR DESCRIPTION
When saving in Laravel's cache, the lifetime was being inadvertently set to 60 times the intended length, due to passing seconds instead of minutes.

Because of this, LaravelCacheStorage::fetch would return stale entries. CacheEntry would correctly identify the entry as stale and perform a fresh request, but because LaravelCacheStorage uses Laravel's Cache::add, LaravelCacheStorage::save would return false and the cache would fail to be added as Cache::add would not write due to existing presence of a CacheEntry at the key provided. In effect, this would cause caching to fail from `getTTL()` to `getTTL() * 59` seconds after initial entry (until Laravel's cache would expire and save would succeed).