### PR TITLE
cache now respects vary headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ before_script:
 cache:
   directories:
   - vendor
+
+script:
+  - vendor/bin/phpunit

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -127,9 +127,7 @@ class CacheEntry
                 return false;
             }
 
-            $varyHeaders = new KeyValueHttpHeader($this->response->getHeader('Vary'));
-
-            foreach ($varyHeaders as $key => $value) {
+            foreach ($this->getVaryHeaders() as $key => $value) {
                 if (!$this->request->hasHeader($key)
                     && !$request->hasHeader($key)
                 ) {
@@ -147,6 +145,16 @@ class CacheEntry
         }
 
         return true;
+    }
+
+    /**
+     * Get the vary headers that should be honoured by the cache.
+     *
+     * @return KeyValueHttpHeader
+     */
+    public function getVaryHeaders()
+    {
+        return new KeyValueHttpHeader($this->response->getHeader('Vary'));
     }
 
     /**

--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -3,6 +3,7 @@
 namespace Kevinrob\GuzzleCache\Strategy;
 
 use Kevinrob\GuzzleCache\CacheEntry;
+use Kevinrob\GuzzleCache\KeyValueHttpHeader;
 use Kevinrob\GuzzleCache\Storage\CacheStorageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -30,7 +31,7 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
         parent::__construct($cache);
     }
 
-    protected function getCacheKey(RequestInterface $request)
+    protected function getCacheKey(RequestInterface $request, KeyValueHttpHeader $varyHeaders = null)
     {
         return hash(
             'sha256',

--- a/src/Strategy/PrivateCacheStrategy.php
+++ b/src/Strategy/PrivateCacheStrategy.php
@@ -113,16 +113,28 @@ class PrivateCacheStrategy implements CacheStrategyInterface
     }
 
     /**
-     * @param RequestInterface $request
+     * Generate a key for the response cache.
+     *
+     * @param RequestInterface   $request
+     * @param KeyValueHttpHeader $varyHeaders The vary headers which should be honoured by the cache (optional)
      *
      * @return string
      */
-    protected function getCacheKey(RequestInterface $request)
+    protected function getCacheKey(RequestInterface $request, KeyValueHttpHeader $varyHeaders = null)
     {
-        return hash(
-            'sha256',
-            $request->getMethod().$request->getUri()
-        );
+        if (!$varyHeaders) {
+            return hash('sha256', $request->getMethod().$request->getUri());
+        }
+
+        $cacheHeaders = [];
+
+        foreach ($varyHeaders as $key => $value) {
+            if ($request->hasHeader($key)) {
+                $cacheHeaders[$key] = $request->getHeader($key);
+            }
+        }
+
+        return hash('sha256', $request->getMethod().$request->getUri().json_encode($cacheHeaders));
     }
 
     /**
@@ -155,6 +167,17 @@ class PrivateCacheStrategy implements CacheStrategyInterface
 
         $cache = $this->storage->fetch($this->getCacheKey($request));
         if ($cache !== null) {
+            $varyHeaders = $cache->getVaryHeaders();
+
+            // vary headers exist from a previous response, check if we have a cache that matches those headers
+            if (!$varyHeaders->isEmpty()) {
+                $cache = $this->storage->fetch($this->getCacheKey($request, $varyHeaders));
+
+                if (!$cache) {
+                    return null;
+                }
+            }
+
             if ((string)$cache->getOriginalRequest()->getUri() !== (string)$request->getUri()) {
                 return null;
             }
@@ -190,10 +213,21 @@ class PrivateCacheStrategy implements CacheStrategyInterface
 
         $cacheObject = $this->getCacheObject($request, $response);
         if ($cacheObject !== null) {
-            return $this->storage->save(
+            // store the cache against the URI-only key
+            $success = $this->storage->save(
                 $this->getCacheKey($request),
                 $cacheObject
             );
+
+            if ($varyHeaders = $cacheObject->getVaryHeaders()) {
+                // also store the cache against the vary headers based key
+                $success = $this->storage->save(
+                    $this->getCacheKey($request, $varyHeaders),
+                    $cacheObject
+                );
+            }
+
+            return $success;
         }
 
         return false;

--- a/src/Strategy/PrivateCacheStrategy.php
+++ b/src/Strategy/PrivateCacheStrategy.php
@@ -219,7 +219,9 @@ class PrivateCacheStrategy implements CacheStrategyInterface
                 $cacheObject
             );
 
-            if ($varyHeaders = $cacheObject->getVaryHeaders()) {
+            $varyHeaders = $cacheObject->getVaryHeaders();
+
+            if (!$varyHeaders->isEmpty()) {
                 // also store the cache against the vary headers based key
                 $success = $this->storage->save(
                     $this->getCacheKey($request, $varyHeaders),

--- a/tests/ResponseVaryTest.php
+++ b/tests/ResponseVaryTest.php
@@ -44,7 +44,7 @@ class ResponseVaryTest extends \PHPUnit_Framework_TestCase
         $this->client = new Client(['handler' => $stack]);
     }
 
-    public function testVaryAllHeader()
+    public function testVaryAllHeaderDoesNotCache()
     {
         $this->client->get('http://test.com/vary-all');
 
@@ -90,6 +90,76 @@ class ResponseVaryTest extends \PHPUnit_Framework_TestCase
         $response = $this->client->get('http://test.com/vary-my-header');
         $this->assertEquals(
             CacheMiddleware::HEADER_CACHE_MISS,
+            $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+    }
+
+    public function testVaryHeadersHaveUniqueCache()
+    {
+        $headerSetA = [
+            'My-Header' => 'hello'
+        ];
+
+        $headerSetB = [
+            'My-Header' => 'goodbye'
+        ];
+
+        $this->client->get('http://test.com/vary-my-header', [
+            'headers' => $headerSetA
+        ]);
+
+        // Second request with A headers - cache hit
+        $response = $this->client->get('http://test.com/vary-my-header', [
+            'headers' => $headerSetA
+        ]);
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_HIT,
+            $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+
+        // First request with B headers - cache miss
+        $response = $this->client->get('http://test.com/vary-my-header', [
+            'headers' => $headerSetB
+        ]);
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_MISS,
+            $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+
+        // Second request with B headers - cache hit
+        $response = $this->client->get('http://test.com/vary-my-header', [
+            'headers' => $headerSetB
+        ]);
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_HIT,
+            $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+
+        // Third request with A headers - cache hit (make sure B cache did not overwrite A cache)
+        $response = $this->client->get('http://test.com/vary-my-header', [
+            'headers' => $headerSetA
+        ]);
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_HIT,
+            $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+    }
+
+    public function testVaryHeaderCaseChangeDoesNotCauseCacheMiss()
+    {
+        $this->client->get('http://test.com/vary-my-header', [
+            'headers' => [
+                'My-Header' => 'hello'
+            ]
+        ]);
+
+        $response = $this->client->get('http://test.com/vary-my-header', [
+            'headers' => [
+                'my-header' => 'hello'
+            ]
+        ]);
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_HIT,
             $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
         );
     }


### PR DESCRIPTION
This PR adds support for respecting the Vary headers returned by the response.

It works by creating a second cache entry with a key based on a hash of the http method, URI, and the values of the vary headers in the request.

If additional requests are sent with the same values for those headers, then the cache will be hit. If the header values differ, the cache will be missed.

**BC breaks**
Using this will invalidate any caches for responses that specify Vary headers. Responses that did not specify Vary headers should just use the existing cache key and return as before.

**Performance concerns**
Before this patch, any requests that changed Vary header values would always result in a cache miss, so this should generally give better performance if your Vary headers change somewhat frequently (e.g. Accept-Language, etc).

If Vary headers exist in the response, this will result in an additional save call, and the associated overhead of storing an extra CacheEntry per header variant.

It also requires an additional cache lookup on read (once to get the URI-only cache to retrieve the Vary headers, then another to fetch the specific CacheEntry for those headers).

