### PR TITLE
Test missing headers in responses

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
 before_script:
   - composer install -n
 
+script:
+  - vendor/bin/phpunit
+
 cache:
   directories:
   - vendor

--- a/tests/ResponseCacheControlTest.php
+++ b/tests/ResponseCacheControlTest.php
@@ -51,6 +51,10 @@ class ResponseCacheControlTest extends \PHPUnit_Framework_TestCase
                             ->withAddedHeader('Cache-Control', 'public')
                             ->withAddedHeader('Expires', gmdate('D, d M Y H:i:s T', time() + 2))
                     );
+              case '/no-headers':
+                    return new FulfilledPromise(
+                      (new Response())
+                    );
             }
 
             throw new \InvalidArgumentException();
@@ -117,4 +121,21 @@ class ResponseCacheControlTest extends \PHPUnit_Framework_TestCase
         $response = $this->client->get('http://test.com/2s-expires');
         $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
     }
+
+    /**
+     * Test responses with no caching headers.
+     *
+     * When neither a Cache-Control or Expires header is set, caching behaviour
+     * is undefined as per section 13.4 in RFC2616. The current behaviour is to
+     * not cache those requests.
+     *
+     * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+     */
+    public function testWithMissingCacheHeaders()
+    {
+        $this->client->get('http://test.com/no-headers');
+        $response = $this->client->get('http://test.com/no-headers');
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+    }
+
 }


### PR DESCRIPTION
I was curious how the middleware handled responses with no cache directives, so I wrote a test for it. I also added an editorconfig file based on what I see in the repository already.