### PR TITLE
Don't typehint when handling rejections

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -6,12 +6,12 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use function GuzzleHttp\Promise\rejection_for;
 
 /**
  * Class CacheMiddleware.
@@ -224,7 +224,7 @@ class CacheMiddleware
                         }
                     }
 
-                    return rejection_for($reason);
+                    return new RejectedPromise($reason);
                 }
             );
         };

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -11,6 +11,7 @@ use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use function GuzzleHttp\Promise\rejection_for;
 
 /**
  * Class CacheMiddleware.
@@ -215,15 +216,15 @@ class CacheMiddleware
 
                     return self::addToCache($this->cacheStorage, $request, $response, $update);
                 },
-                function (\Exception $ex) use ($cacheEntry) {
-                    if ($ex instanceof TransferException) {
+                function ($reason) use ($cacheEntry) {
+                    if ($reason instanceof TransferException) {
                         $response = static::getStaleResponse($cacheEntry);
                         if ($response instanceof ResponseInterface) {
                             return $response;
                         }
                     }
 
-                    throw $ex;
+                    return rejection_for($reason);
                 }
             );
         };


### PR DESCRIPTION
Promises can be rejected with a `string` (this would also have failed with a PHP7 `Throwable`).