### PR TITLE
Implement WordPress Object Cache storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A HTTP Cache for [Guzzle](https://github.com/guzzle/guzzle) 6. It's a simple Mid
 - [Laravel cache](https://laravel.com/docs/5.2/cache)
 - [Flysystem](https://github.com/thephpleague/flysystem)
 - [PSR6](https://github.com/php-fig/cache)
+- [WordPress Object Cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache)
 
 ## Installation
 
@@ -129,6 +130,24 @@ $stack->push(
       )
     )
   ), 
+  'cache'
+);
+```
+
+## WordPress Object Cache
+```php
+[...]
+use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
+use Kevinrob\GuzzleCache\Storage\WordPressObjectCacheStorage;
+
+[...]
+
+$stack->push(
+  new CacheMiddleware(
+    new PrivateCacheStrategy(
+      new WordPressObjectCacheStorage()
+    )
+  ),
   'cache'
 );
 ```

--- a/src/Storage/WordPressObjectCacheStorage.php
+++ b/src/Storage/WordPressObjectCacheStorage.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Kevinrob\GuzzleCache\Storage;
+
+use Kevinrob\GuzzleCache\CacheEntry;
+
+class WordPressObjectCacheStorage implements CacheStorageInterface
+{
+    /**
+     * @var string
+     */
+    private $group;
+
+    /**
+     * @param string $group
+     */
+    public function __construct($group = 'guzzle')
+    {
+        $this->group = $group;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return CacheEntry|null the data or false
+     */
+    public function fetch($key)
+    {
+        try {
+            $cache = unserialize(wp_cache_get($key, $this->group));
+            if ($cache instanceof CacheEntry) {
+                return $cache;
+            }
+        } catch (\Exception $ignored) {
+            // Don't fail if we can't load it
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $key
+     * @param CacheEntry $data
+     *
+     * @return bool
+     */
+    public function save($key, CacheEntry $data)
+    {
+        try {
+            return wp_cache_set($key, serialize($data), $this->group, $data->getTTL());
+        } catch (\Exception $ignored) {
+            // Don't fail if we can't save it
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Implements cache storage using WP's Object Cache - useful when Guzzle is used on a WordPress site.