### PR TITLE
Greedy cache strategy improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Using the greedy caching strategy allows defining an expiry TTL on your own whil
 disregarding any possibly present caching headers:
 ```php
 [...]
+use Kevinrob\GuzzleCache\KeyValueHttpHeader;
 use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
 use Kevinrob\GuzzleCache\Storage\DoctrineCacheStorage;
 use Doctrine\Common\Cache\FilesystemCache;
@@ -189,7 +190,8 @@ $stack->push(
       new DoctrineCacheStorage(
         new FilesystemCache('/tmp/')
       ),
-      1800 // the TTL in seconds
+      1800, // the TTL in seconds
+      new KeyValueHttpHeader(['Authorization']) // Optionnal - specify the headers that can change the cache key
     )
   ), 
   'greedy-cache'

--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -33,7 +33,6 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
     {
         $this->ttl = $ttl;
         $this->varyHeaders = $varyHeaders;
-
         parent::__construct($cache);
     }
 
@@ -45,8 +44,8 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
                 'greedy'.$request->getMethod().$request->getUri()
             );
         }
-        $cacheHeaders = [];
 
+        $cacheHeaders = [];
         foreach ($varyHeaders as $key => $value) {
             if ($request->hasHeader($key)) {
                 $cacheHeaders[$key] = $request->getHeader($key);
@@ -70,9 +69,8 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
         $response = $response->withAddedHeader('Warning', $warningMessage);
 
         if ($cacheObject = $this->getCacheObject($request, $response)) {
-            $varyHeaders = $this->varyHeaders;
             return $this->storage->save(
-                $this->getCacheKey($request, $varyHeaders),
+                $this->getCacheKey($request, $this->varyHeaders),
                 $cacheObject
             );
         }
@@ -86,9 +84,8 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
             // Don't cache it
             return null;
         }
-        $varyHeader = $this->varyHeaders;
 
-        if (null !== $varyHeader && $varyHeader->has('*')) {
+        if (null !== $this->varyHeaders && $this->varyHeaders->has('*')) {
             // This will never match with a request
             return;
         }

--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -24,18 +24,38 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
      */
     protected $ttl;
 
-    public function __construct(CacheStorageInterface $cache = null, $ttl)
+    /**
+     * @var KeyValueHttpHeader
+     */
+    private $varyHeaders;
+
+    public function __construct(CacheStorageInterface $cache = null, $ttl, KeyValueHttpHeader $varyHeaders = null)
     {
         $this->ttl = $ttl;
+        $this->varyHeaders = $varyHeaders;
 
         parent::__construct($cache);
     }
 
     protected function getCacheKey(RequestInterface $request, KeyValueHttpHeader $varyHeaders = null)
     {
+        if (null === $varyHeaders || $varyHeaders->isEmpty()) {
+            return hash(
+                'sha256',
+                'greedy'.$request->getMethod().$request->getUri()
+            );
+        }
+        $cacheHeaders = [];
+
+        foreach ($varyHeaders as $key => $value) {
+            if ($request->hasHeader($key)) {
+                $cacheHeaders[$key] = $request->getHeader($key);
+            }
+        }
+
         return hash(
             'sha256',
-            'greedy'.$request->getMethod().$request->getUri()
+            'greedy'.$request->getMethod().$request->getUri().json_encode($cacheHeaders)
         );
     }
 
@@ -50,8 +70,9 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
         $response = $response->withAddedHeader('Warning', $warningMessage);
 
         if ($cacheObject = $this->getCacheObject($request, $response)) {
+            $varyHeaders = $this->varyHeaders;
             return $this->storage->save(
-                $this->getCacheKey($request),
+                $this->getCacheKey($request, $varyHeaders),
                 $cacheObject
             );
         }
@@ -65,12 +86,20 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
             // Don't cache it
             return null;
         }
+        $varyHeader = $this->varyHeaders;
+
+        if (null !== $varyHeader && $varyHeader->has('*')) {
+            // This will never match with a request
+            return;
+        }
+
 
         return new CacheEntry($request, $response, new \DateTime(sprintf('+%d seconds', $this->ttl)));
     }
 
     public function fetch(RequestInterface $request)
     {
-        return $this->storage->fetch($this->getCacheKey($request));
+        $cache = $this->storage->fetch($this->getCacheKey($request, $this->varyHeaders));
+        return $cache;
     }
 }

--- a/tests/GreedyCacheTest.php
+++ b/tests/GreedyCacheTest.php
@@ -3,6 +3,7 @@
 namespace Kevinrob\GuzzleCache;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Request;
@@ -52,7 +53,7 @@ class GreedyCacheTest extends \PHPUnit_Framework_TestCase
         });
 
         $stack->push(new CacheMiddleware(
-            new GreedyCacheStrategy(null, 10))
+                new GreedyCacheStrategy(null, 10))
         );
 
         $this->client = new Client(['handler' => $stack]);
@@ -85,6 +86,47 @@ class GreedyCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
     }
 
+    /**
+     * @param Request $requestA
+     * @param Request $requestB
+     * @param Request $requestC
+     * @param Request $requestD
+     *
+     * @dataProvider varyingCachableRequestProvider
+     */
+    public function testItCanHandleArbitraryVaryingHeaders(Request $requestA, Request $requestB, Request $requestC, Request $requestD)
+    {
+        $stack = HandlerStack::create(new MockHandler([
+            new Response(),
+            new Response(),
+            new Response(),
+            new Response(),
+        ]));
+
+        $stack->push(new CacheMiddleware(
+                new GreedyCacheStrategy(
+                    null,
+                    10,
+                    new KeyValueHttpHeader(['Authorization'])
+                ))
+        );
+
+        $this->client = new Client([
+            'handler' => $stack
+        ]);
+
+        $responseA = $this->client->send($requestA);
+        $responseB = $this->client->send($requestB);
+        $responseC = $this->client->send($requestC);
+        $responseD = $this->client->send($requestD);
+
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $responseA->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $responseB->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $responseC->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $responseD->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+
+    }
+
     public function cachableRequestProvider()
     {
         return [
@@ -100,6 +142,18 @@ class GreedyCacheTest extends \PHPUnit_Framework_TestCase
         return [
             [new Request('POST', '/vary')],
             [new Request('GET', '/partial-content')],
+        ];
+    }
+
+    public function varyingCachableRequestProvider()
+    {
+        return [
+            [
+                'A' => new Request('GET', '/something', ['Authorization' => 'Bearer foo']), // Should not be cached
+                'B' => new Request('GET', '/something', ['Authorization' => 'Bearer bar']), // Same URI but different authorization - should not be cached
+                'C' => new Request('GET', '/something', ['Authorization' => 'Bearer foo']), // Same authorization token as request A - should be cached
+                'D' => new Request('GET', '/some_other_thing', ['Authorization' => 'Bearer foo']), // Same authorization token as request A and C, but different URI - should not be cached
+            ]
         ];
     }
 }


### PR DESCRIPTION
Hi there,

TL; DR;
-----------
New feature: allow `GreedyCacheStrategy` to generate the cache key based on specific headers.

Introduction
----------------
I'm currently working with several heavy partner APIs that don't care much about cache headers.
So I'm using the `GreedyCacheStrategy` to cache their responses.
Problem: I use several accounts for these APIs, within the same app. To describe this in gherkin language:

```gherkin
Background:
  Given I'm authenticated on the API with UserA
  And I have fetched http://some-api.com/campaigns
  And The response has been stored in the cache

  Scenario: Ask the same resource for another user
    When I authenticate on the API with UserB
    And I fetch http://some-api.com/campaigns
    Then I should not get UserA's campaigns
    But I should get UserB's campaigns
    And The response should be stored in the cache
```
Currently, when I'm logged in with `UserA`, and I fetch and cache the resource `/campaigns`, and then, later, I log in as `UserB`, and I fetch the same resource `/campaigns`, I get `UserA`'s _cached_ campaigns.

To prevent this behaviour, I added an option into the `GreedyCacheStrategy` that allow to specify a `KeyValueHttpHeader` into its constructor, which will help in generating a different cache key, based on specific headers.

Example
------------

```php
require_once __DIR__ . '/vendor/autoload.php';

use GuzzleHttp\Client;
use GuzzleHttp\HandlerStack;
use GuzzleHttp\Psr7\Request;
use Kevinrob\GuzzleCache\CacheMiddleware;
use Kevinrob\GuzzleCache\KeyValueHttpHeader;
use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;

$stack = HandlerStack::create();
$stack->push(new CacheMiddleware(
    new GreedyCacheStrategy(
        null,
        10,
        new KeyValueHttpHeader(['Authorization'])
    )
));
$guzzle = new Client(['handler' => $stack]);

$request = new Request('GET', 'http://httpbin.org/get');
$billGates = 'Microsoft is great';
$timCook = 'Apple is better';

$responses = [
    $guzzle->send($request->withAddedHeader('Authorization', 'Bearer: ' . $billGates)),
    $guzzle->send($request->withAddedHeader('Authorization', 'Bearer: ' . $timCook)),
    $guzzle->send($request->withAddedHeader('Authorization', 'Bearer: ' . $billGates)),
];

var_dump($responses[0]->getHeaderLine('X-Kevinrob-Cache')); // MISS
var_dump($responses[1]->getHeaderLine('X-Kevinrob-Cache')); // MISS
var_dump($responses[2]->getHeaderLine('X-Kevinrob-Cache')); // HIT
```
There's no BC break since it's a new, optionnal feature.
When no `KeyValueHttpHeader` is provided, the _sha_ is still the same as before.