### PR TITLE
Fix calls to static method addToCache to allow subclasses to override it

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -218,7 +218,7 @@ class CacheMiddleware
                         $response = $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
                     }
 
-                    return self::addToCache($this->cacheStorage, $request, $response, $update);
+                    return static::addToCache($this->cacheStorage, $request, $response, $update);
                 },
                 function ($reason) use ($cacheEntry) {
                     if ($reason instanceof TransferException) {
@@ -300,7 +300,7 @@ class CacheMiddleware
                         $update = true;
                     }
 
-                    self::addToCache($cacheStorage, $request, $response, $update);
+                    static::addToCache($cacheStorage, $request, $response, $update);
                 });
 
             return true;


### PR DESCRIPTION
This method in CacheMiddleware has protected visibility but currently you can't override it unless you also override both the __invoke and addReValidationRequest, as these methods call `self::addToCache` when they should use the `static` keyword instead.