### PR TITLE
Update dependency `cache/array-adapter` to last version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 sudo: false
 language: php
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "doctrine/cache": "^1.0",
     "league/flysystem": "^1.0",
     "psr/cache": "^1.0",
-    "cache/array-adapter": "^0.4",
+    "cache/array-adapter": "^1.0",
     "illuminate/cache": "^5.0"
   },
   "autoload": {


### PR DESCRIPTION
Update dependency `cache/array-adapter` to last version #91 

update composer.json and .travis.yml
cache/array-adapter version 1.0  support php >= 5.6 so remove php 5.5 from test