### PR TITLE
Invalidate cache after a non-safe method on the same URI 

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -113,7 +113,8 @@ class CacheMiddleware
         return function (RequestInterface $request, array $options) use (&$handler) {
             if (!isset($this->httpMethods[strtoupper($request->getMethod())])) {
                 // No caching for this method allowed
-                // Cache after a non-safe method on the same URI will be invalidated
+
+                // Invalidate cache after a non-safe method on the same URI will be invalidated
                 $this->cacheStorage->delete($request);
 
                 return $handler($request, $options)->then(

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -113,6 +113,9 @@ class CacheMiddleware
         return function (RequestInterface $request, array $options) use (&$handler) {
             if (!isset($this->httpMethods[strtoupper($request->getMethod())])) {
                 // No caching for this method allowed
+                // Cache after a non-safe method on the same URI will be invalidated
+                $this->cacheStorage->delete($request);
+
                 return $handler($request, $options)->then(
                     function (ResponseInterface $response) {
                         return $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -114,11 +114,11 @@ class CacheMiddleware
             if (!isset($this->httpMethods[strtoupper($request->getMethod())])) {
                 // No caching for this method allowed
 
-                // Invalidate cache after a non-safe method on the same URI will be invalidated
-                $this->cacheStorage->delete($request);
-
                 return $handler($request, $options)->then(
-                    function (ResponseInterface $response) {
+                    function (ResponseInterface $response) use ($request) {
+                        // Invalidate cache after a call of non-safe method on the same URI
+                        $this->cacheStorage->delete($request);
+
                         return $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
                     }
                 );

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kevinrob\GuzzleCache\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Psr7\NoSeekStream;
+use GuzzleHttp\Psr7\Response;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+use Psr\Http\Message\RequestInterface;
+
+class InvalidateCacheTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    public function setUp()
+    {
+        // Create default HandlerStack
+        $stack = HandlerStack::create(function () {
+            return new FulfilledPromise(new Response());
+        });
+
+        // Add this middleware to the top with `push`
+        $stack->push(new CacheMiddleware(), 'cache');
+
+        // Initialize the client with the handler option
+        $this->client = new Client(['handler' => $stack]);
+    }
+
+    public function testInvalidationCacheIfNotValidHttpMethod()
+    {
+        $response = $this->client->get('anything');
+        $this->assertSame('', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+
+        $response = $this->client->post('anything');
+        $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+
+        $response = $this->client->put('anything');
+        $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+
+        $response = $this->client->delete('anything');
+        $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+
+        $response = $this->client->patch('anything');
+        $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+    }
+}

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -5,10 +5,8 @@ namespace Kevinrob\GuzzleCache\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
-use Psr\Http\Message\RequestInterface;
 
 class InvalidateCacheTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Related to #22 

Deletion of cache data from the request object has been added in the non-safe HTTP method condition. 