### PR TITLE
Fix: laravel has changed cache TTL units

### DIFF
--- a/src/Storage/LaravelCacheStorage.php
+++ b/src/Storage/LaravelCacheStorage.php
@@ -43,8 +43,12 @@ class LaravelCacheStorage implements CacheStorageInterface
     public function save($key, CacheEntry $data)
     {
         try {
-            // getTTL returns seconds, Laravel needs minutes
-            $lifeTime = $data->getTTL() / 60;
+            if (app()->version() < '5.8.0') {
+                // getTTL returns seconds, Laravel needs minutes before v5.8
+                $lifeTime = $data->getTTL() / 60;
+            } else {
+                $lifeTime = $data->getTTL();
+            }
             if ($lifeTime === 0) {
                 return $this->cache->forever(
                     $key,

--- a/src/Storage/LaravelCacheStorage.php
+++ b/src/Storage/LaravelCacheStorage.php
@@ -43,7 +43,7 @@ class LaravelCacheStorage implements CacheStorageInterface
     public function save($key, CacheEntry $data)
     {
         try {
-            if (app()->version() < '5.8.0') {
+            if (version_compare(app()->version(), '5.8.0') < 0) {
                 // getTTL returns seconds, Laravel needs minutes before v5.8
                 $lifeTime = $data->getTTL() / 60;
             } else {


### PR DESCRIPTION
Laravel has changed cache TTL units from minutes to seconds in version 5.8. Code in this PR uses correct units, according to Laravel version.
https://laravel.com/docs/5.7/cache#storing-items-in-the-cache
https://laravel.com/docs/5.8/cache#storing-items-in-the-cache