### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "php": ">=5.5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.0 || ^5.0",
+    "phpunit/phpunit": "^4.8.36 || ^5.0",
     "guzzlehttp/guzzle": "^6.0",
     "doctrine/cache": "^1.0",
     "league/flysystem": "^1.0",

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -9,15 +9,16 @@ use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class BaseTest extends \PHPUnit_Framework_TestCase
+class BaseTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/DelegatingCacheTest.php
+++ b/tests/DelegatingCacheTest.php
@@ -28,7 +28,7 @@ class DelegatingCacheTest extends TestCase
      */
     protected $stack;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $this->stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/GreedyCacheTest.php
+++ b/tests/GreedyCacheTest.php
@@ -12,8 +12,9 @@ use Kevinrob\GuzzleCache\CacheMiddleware;
 use Kevinrob\GuzzleCache\KeyValueHttpHeader;
 use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class GreedyCacheTest extends \PHPUnit_Framework_TestCase
+class GreedyCacheTest extends TestCase
 {
     /**
      * @var Client

--- a/tests/HeaderExpireTest.php
+++ b/tests/HeaderExpireTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Created by IntelliJ IDEA.
@@ -15,7 +16,7 @@ use Psr\Http\Message\RequestInterface;
  * Date: 29.06.2015
  * Time: 22:48.
  */
-class HeaderExpireTest extends \PHPUnit_Framework_TestCase
+class HeaderExpireTest extends TestCase
 {
     /**
      * @var Client
@@ -27,7 +28,7 @@ class HeaderExpireTest extends \PHPUnit_Framework_TestCase
      */
     protected $sendError = false;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -7,15 +7,16 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
+use PHPUnit\Framework\TestCase;
 
-class InvalidateCacheTest extends \PHPUnit_Framework_TestCase
+class InvalidateCacheTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function () {

--- a/tests/KeyValueHttpHeaderTest.php
+++ b/tests/KeyValueHttpHeaderTest.php
@@ -10,8 +10,9 @@ namespace Kevinrob\GuzzleCache\Tests;
 
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\KeyValueHttpHeader;
+use PHPUnit\Framework\TestCase;
 
-class KeyValueHttpHeaderTest extends \PHPUnit_Framework_TestCase
+class KeyValueHttpHeaderTest extends TestCase
 {
     public function testBase()
     {

--- a/tests/PrivateCacheTest.php
+++ b/tests/PrivateCacheTest.php
@@ -19,8 +19,9 @@ use Kevinrob\GuzzleCache\Storage\Psr16CacheStorage;
 use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
 use League\Flysystem\Adapter\Local;
+use PHPUnit\Framework\TestCase;
 
-class PrivateCacheTest extends \PHPUnit_Framework_TestCase
+class PrivateCacheTest extends TestCase
 {
     public function testCacheProvider()
     {

--- a/tests/PublicCacheTest.php
+++ b/tests/PublicCacheTest.php
@@ -24,15 +24,16 @@ use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use Kevinrob\GuzzleCache\Strategy\PublicCacheStrategy;
 use League\Flysystem\Adapter\Local;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class PublicCacheTest extends \PHPUnit_Framework_TestCase
+class PublicCacheTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/RequestCacheControlTest.php
+++ b/tests/RequestCacheControlTest.php
@@ -8,15 +8,16 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class RequestCacheControlTest extends \PHPUnit_Framework_TestCase
+class RequestCacheControlTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/ResponseAgeTest.php
+++ b/tests/ResponseAgeTest.php
@@ -8,15 +8,16 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class ResponseAgeTest extends \PHPUnit_Framework_TestCase
+class ResponseAgeTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/ResponseCacheControlTest.php
+++ b/tests/ResponseCacheControlTest.php
@@ -8,15 +8,16 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class ResponseCacheControlTest extends \PHPUnit_Framework_TestCase
+class ResponseCacheControlTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/ResponseVaryTest.php
+++ b/tests/ResponseVaryTest.php
@@ -8,15 +8,16 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class ResponseVaryTest extends \PHPUnit_Framework_TestCase
+class ResponseVaryTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/Strategy/GreedyCacheStrategyTest.php
+++ b/tests/Strategy/GreedyCacheStrategyTest.php
@@ -10,15 +10,16 @@ use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class GreedyCacheStrategyTest extends \PHPUnit_Framework_TestCase
+class GreedyCacheStrategyTest extends TestCase
 {
     /**
      * @var Client
      */
     protected $client;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Created by IntelliJ IDEA.
@@ -15,7 +16,7 @@ use Psr\Http\Message\RequestInterface;
  * Date: 30.06.2015
  * Time: 12:58.
  */
-class ValidationTest extends \PHPUnit_Framework_TestCase
+class ValidationTest extends TestCase
 {
     /**
      * @var Client
@@ -27,7 +28,7 @@ class ValidationTest extends \PHPUnit_Framework_TestCase
      */
     protected $cache;
 
-    public function setUp()
+    protected function setUp()
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function (RequestInterface $request, array $options) {


### PR DESCRIPTION
# Changed log
- Add other stable PHP versions during Travis CI build.
- To support future stable PHPUnit version, using the `PHPUnit\Framework\TestCase` namespace instead.
- According to the [PHPUnit fixtures reference](https://phpunit.de/manual/5.7/en/fixtures.html), the `setUp` method is `protected`, not `public`.