### PR TITLE
Also put entries into the cache that allow stale-while-revalidate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "cache/array-adapter": "^0.4 || ^0.5 || ^1.0",
     "illuminate/cache": "^5.0",
     "cache/simple-cache-bridge": "^0.1 || ^1.0",
-    "symfony/phpunit-bridge": "^5.0"
+    "symfony/phpunit-bridge": "^4.4 || ^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "psr/cache": "^1.0",
     "cache/array-adapter": "^0.4 || ^0.5 || ^1.0",
     "illuminate/cache": "^5.0",
-    "cache/simple-cache-bridge": "^0.1 || ^1.0"
+    "cache/simple-cache-bridge": "^0.1 || ^1.0",
+    "symfony/phpunit-bridge": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,4 +21,8 @@
     <log type="coverage-clover" target="coverage.xml"/>
   </logging>
 
+  <listeners>
+    <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
+
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,9 @@
          colors="true"
          bootstrap="./vendor/autoload.php"
 >
+  <php>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+  </php>
 
   <testsuites>
     <testsuite name="Project Test Suite">

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -230,14 +230,21 @@ class CacheEntry
             return 0;
         }
 
+        $ttl = 0;
+
+        // Keep it when stale if error
         if ($this->staleIfErrorTo !== null) {
-            // Keep it when stale if error
-            $ttl = $this->staleIfErrorTo->getTimestamp() - time();
-        } else {
-            // Keep it until it become stale
-            $ttl = $this->staleAt->getTimestamp() - time();
+            $ttl = max($ttl, $this->staleIfErrorTo->getTimestamp() - time());
         }
 
+        // Keep it when stale-while-revalidate
+        if ($this->staleWhileRevalidateTo !== null) {
+            $ttl = max($ttl, $this->staleWhileRevalidateTo->getTimestamp() - time());
+        }
+
+        // Keep it until it become stale
+        $ttl = max($ttl, $this->staleAt->getTimestamp() - time());
+        
         // Don't return 0, it's reserved for infinite TTL
         return $ttl !== 0 ? (int) $ttl : -1;
     }

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -223,9 +223,9 @@ class CacheEntry
     /**
      * Time in seconds how long the entry should be kept in the cache
      *
-     * This is not the TTL that a response is still fresh from the HTTP point
-     * of view, but an upper bound on how long it is necessary and reasonable to
-     * keep the response in a cache.
+     * This will not give the time (in seconds) that the response will still be fresh for
+     * from the HTTP point of view, but an upper bound on how long it is necessary and
+     * reasonable to keep the response in a cache (to re-use it or re-validate it later on).
      *
      * @return int TTL in seconds (0 = infinite)
      */

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -221,6 +221,12 @@ class CacheEntry
     }
 
     /**
+     * Time in seconds how long the entry should be kept in the cache
+     *
+     * This is not the TTL that a response is still fresh from the HTTP point
+     * of view, but an upper bound on how long it is necessary and reasonable to
+     * keep the response in a cache.
+     *
      * @return int TTL in seconds (0 = infinite)
      */
     public function getTTL()
@@ -244,7 +250,7 @@ class CacheEntry
 
         // Keep it until it become stale
         $ttl = max($ttl, $this->staleAt->getTimestamp() - time());
-        
+
         // Don't return 0, it's reserved for infinite TTL
         return $ttl !== 0 ? (int) $ttl : -1;
     }

--- a/tests/CacheEntryTest.php
+++ b/tests/CacheEntryTest.php
@@ -26,8 +26,8 @@ class CacheEntryTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->request = $this->createMock(RequestInterface::class);
-        $this->response = $this->createMock(ResponseInterface::class);
+        $this->request = $this->getMockBuilder(RequestInterface::class)->getMock();
+        $this->response = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $this->response->method('getHeader')->will($this->returnCallback(function ($header) {
             if (isset($this->responseHeaders[$header])) {
                 return $this->responseHeaders[$header];

--- a/tests/CacheEntryTest.php
+++ b/tests/CacheEntryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Kevinrob\GuzzleCache\Tests;
+
+use Kevinrob\GuzzleCache\CacheEntry;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @group time-sensitive
+ */
+class CacheEntryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    private $responseHeaders = [];
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->request = $this->createMock(RequestInterface::class);
+        $this->response = $this->createMock(ResponseInterface::class);
+        $this->response->method('getHeader')->will($this->returnCallback(function ($header) {
+            if (isset($this->responseHeaders[$header])) {
+                return $this->responseHeaders[$header];
+            }
+
+            return [];
+        }));
+        $this->response->method('hasHeader')->will($this->returnCallback(function ($header) {
+            return isset($this->responseHeaders[$header]);
+        }));
+    }
+
+    public function testTtlForValidateableResponseShouldBeInfinite()
+    {
+        $this->setResponseHeader('Etag', 'some-etag');
+        $cacheEntry = new CacheEntry($this->request, $this->response, $this->makeDateTimeOffset());
+
+        // getTTL() will return 0 to indicate "infinite"
+        $this->assertEquals(0, $cacheEntry->getTTL());
+    }
+
+    public function testTtlForSimpleExpiration()
+    {
+        $cacheEntry = new CacheEntry($this->request, $this->response, $this->makeDateTimeOffset(10));
+
+        $this->assertEquals(10, $cacheEntry->getTTL());
+    }
+
+    public function testTtlConsidersStaleIfError()
+    {
+        $this->setResponseHeader('Cache-Control', 'stale-if-error=30');
+        $cacheEntry = new CacheEntry($this->request, $this->response, $this->makeDateTimeOffset(10));
+
+        $this->assertEquals(40, $cacheEntry->getTTL());
+    }
+
+    public function testTtlConsidersStaleWhileRevalidate()
+    {
+        $this->setResponseHeader('Cache-Control', 'stale-while-revalidate=30');
+        $cacheEntry = new CacheEntry($this->request, $this->response, $this->makeDateTimeOffset(10));
+
+        $this->assertEquals(40, $cacheEntry->getTTL());
+    }
+
+    public function testTtlUsesMaximumPossibleLifetime()
+    {
+        $this->setResponseHeader('Cache-Control', 'stale-while-revalidate=30, stale-if-error=60');
+        $cacheEntry = new CacheEntry($this->request, $this->response, $this->makeDateTimeOffset(10));
+
+        $this->assertEquals(70, $cacheEntry->getTTL());
+    }
+
+    private function setResponseHeader($name, $value)
+    {
+        $this->responseHeaders[$name] = [$value];
+    }
+
+    private function makeDateTimeOffset($offset = 0)
+    {
+        return \DateTime::createFromFormat('U', time() + $offset);
+    }
+}


### PR DESCRIPTION
The `stale-while-revalidate` timeout is not taken into consideration when computing the TTL for the cache entry. The result is that the underlying cache layer will discard cache entries once they become stale.

This effectively prevents `stale-while-revalidate` behavior, since the cached entry is no longer available when the `stale` period begins (and revalidation could happen in the background).
