### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^6.0 || ^7.0",
+    "guzzlehttp/guzzle": "^6.0 || ^7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8.36 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0"
+    "php": ">=5.5.0",
+    "guzzlehttp/guzzle": "^6.0 || ^7.0",
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8.36 || ^5.0",
-    "guzzlehttp/guzzle": "^6.0",
     "doctrine/cache": "^1.0",
     "league/flysystem": "^1.0",
     "psr/cache": "^1.0",


### PR DESCRIPTION
Hi,

We have recently tagged a new version 7 of guzzle.

🎉 https://github.com/guzzle/guzzle/releases/tag/7.0.0

Btw I am really confused.. since this repo is a "Guzzle" middleware.. why guzzle is at require-dev ?