### PR TITLE
Improve class namespace and assertions

### DIFF
--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -49,7 +49,7 @@ class BaseTest extends TestCase
         $response = $this->client->get('anything');
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('Hello world!', $response->getBody());
+        $this->assertSame('Hello world!', (string)$response->getBody());
         $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
 
         $response = $this->client->get('anything');

--- a/tests/KeyValueHttpHeaderTest.php
+++ b/tests/KeyValueHttpHeaderTest.php
@@ -39,7 +39,7 @@ class KeyValueHttpHeaderTest extends TestCase
         $this->assertTrue($values->has('with-comma'));
         $this->assertTrue($values->has('yeah'));
 
-        $this->assertEquals(120, $values->get('max-age'));
+        $this->assertSame('120', $values->get('max-age'));
         $this->assertEquals(60, $values->get('stale-while-revalidate'));
         $this->assertEquals(0, $values->get('zero'));
         $this->assertEquals('', $values->get('nothing'));

--- a/tests/Strategy/GreedyCacheStrategyTest.php
+++ b/tests/Strategy/GreedyCacheStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kevinrob\GuzzleCache\Strategy;
+namespace Kevinrob\GuzzleCache\Tests\Strategy;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Strategy\GreedyCacheStrategy;
 use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
# Changed log

- Fix the class namespace for `tests/Strategy/GreedyCacheStrategyTest.php` class to be compatible with `PSR-4` autoloading.
- Using the `assertSame` to assert the expected is same as result strictly.