### PR TITLE
Don't store keys without an expiry

### DIFF
--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -231,10 +231,6 @@ class CacheEntry
      */
     public function getTTL()
     {
-        if ($this->hasValidationInformation()) {
-            // No TTL if we have a way to re-validate the cache
-            return 0;
-        }
 
         $ttl = 0;
 

--- a/tests/CacheEntryTest.php
+++ b/tests/CacheEntryTest.php
@@ -40,15 +40,6 @@ class CacheEntryTest extends \PHPUnit_Framework_TestCase
         }));
     }
 
-    public function testTtlForValidateableResponseShouldBeInfinite()
-    {
-        $this->setResponseHeader('Etag', 'some-etag');
-        $cacheEntry = new CacheEntry($this->request, $this->response, $this->makeDateTimeOffset());
-
-        // getTTL() will return 0 to indicate "infinite"
-        $this->assertEquals(0, $cacheEntry->getTTL());
-    }
-
     public function testTtlForSimpleExpiration()
     {
         $cacheEntry = new CacheEntry($this->request, $this->response, $this->makeDateTimeOffset(10));


### PR DESCRIPTION
We see weird behaviour in our redis cluster when we have many keys without an expiry.

I don't believe the current behaviour is beneficial because a revalidation will only happen if there is a swr value and it's in the future- a cached response that exceeds the swr won't revalidate.