### PR TITLE
Fix #148 igbinary_serialize cannot serialize resource(stream)

### DIFF
--- a/src/BodyStore.php
+++ b/src/BodyStore.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kevinrob\GuzzleCache;
+
+/**
+ *
+ * This object is only meant to provide a callable to `GuzzleHttp\Psr7\PumpStream`.
+ *
+ * @internal don't use it in your project.
+ */
+class BodyStore
+{
+    private $body;
+
+    private $read = 0;
+
+    private $toRead;
+
+    public function __construct(string $body)
+    {
+        $this->body = $body;
+        $this->toRead = mb_strlen($this->body);
+    }
+
+    /**
+     * @param int $length
+     * @return false|string
+     */
+    public function __invoke(int $length)
+    {
+        if ($this->toRead <= 0) {
+            return false;
+        }
+
+        $length = min($length, $this->toRead);
+
+        $body = mb_substr(
+            $this->body,
+            $this->read,
+            $length
+        );
+        $this->toRead -= $length;
+        $this->read += $length;
+        return $body;
+    }
+}

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -2,6 +2,7 @@
 
 namespace Kevinrob\GuzzleCache;
 
+use GuzzleHttp\Psr7\PumpStream;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -16,14 +17,6 @@ class CacheEntry
      * @var ResponseInterface
      */
     protected $response;
-
-    /**
-     * This field is only used for serialize.
-     * Response::body is a stream and can't be serialized.
-     *
-     * @var string
-     */
-    protected $responseBody;
 
     /**
      * @var \DateTime
@@ -265,23 +258,19 @@ class CacheEntry
 
     public function __sleep()
     {
-        // Stream/Resource can't be serialized... So we copy the content
+        // Stream/Resource can't be serialized... So we copy the content into an implementation of `Psr\Http\Message\StreamInterface`
         if ($this->response !== null) {
-            $this->responseBody = (string) $this->response->getBody();
-            $this->response->getBody()->rewind();
+            $body = (string)$this->response->getBody();
+            $this->response = $this->response->withBody(
+                new PumpStream(
+                    new BodyStore($body),
+                    [
+                        'size' => mb_strlen($body)
+                    ]
+                )
+            );
         }
 
         return array_keys(get_object_vars($this));
-    }
-
-    public function __wakeup()
-    {
-        // We re-create the stream of the response
-        if ($this->response !== null) {
-            $this->response = $this->response
-                ->withBody(
-                    \GuzzleHttp\Psr7\Utils::streamFor($this->responseBody)
-                );
-        }
     }
 }

--- a/tests/BodyStoreTest.php
+++ b/tests/BodyStoreTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kevinrob\GuzzleCache\Tests;
+
+use http\Message\Body;
+use Kevinrob\GuzzleCache\BodyStore;
+use PHPUnit\Framework\TestCase;
+
+class BodyStoreTest extends TestCase
+{
+    public function testBodyStoreReturnsAllContentIfAskedLengthIsGreaterThanAvailable()
+    {
+        $str = 'Not so long';
+        $bodyStore = new BodyStore($str);
+        $this->assertEquals($str, $bodyStore(PHP_INT_MAX));
+    }
+
+    public function testBodyStoreReturnsFalseIsAllHasBeenRead()
+    {
+        $str = 'Not so long';
+        $bodyStore = new BodyStore($str);
+        $bodyStore(PHP_INT_MAX);
+        $this->assertFalse($bodyStore(1));
+    }
+
+    public function testBodyStoreCanReadAllContentWhenIteratedEnough()
+    {
+        $originalString = <<<EOF
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+EOF;
+        $bodyStore = new BodyStore($originalString);
+
+        $got = '';
+        while ($str = $bodyStore(1)) {
+            $got .= $str;
+        }
+        $this->assertEquals($originalString, $got);
+    }
+
+    public function testBodyStoreReturnsEmptyStringWhenAsking0()
+    {
+        $str = 'Not so long';
+        $bodyStore = new BodyStore($str);
+        $this->assertEquals('', $bodyStore(0));
+    }
+}


### PR DESCRIPTION
When using igbinary_serialize in the process to store a `CacheEntry`, we can get the following warning from PHP: `Message: igbinary_serialize(): Cannot serialize resource(stream) and resources may be converted to objects that cannot be serialized in future php releases. Serializing the value as null instead`. `CacheEntry` already mitigates the fact that a `resource` cannot be serialized, but the `Response` object still contains the `stream` so the warning is still there.

As a workaround, I propose to replace the resource with an instance of `GuzzleHttp\Psr7\PumpStream`, the only implementation of `Psr\Http\Message\StreamInterface` not using a `resource` in its internal, as it's meant to fetch data from a `callback`. In this implementation I've chosen to create a `BodyStore`, with the very minimal logic to return expected data when invoked.

By using this new implementation of `Psr\Http\Message\StreamInterface` for the body, we can totally remove the need to manipulate the `Response` on `__wakeup`