### PR TITLE
Invalidate items for all methods on unsafe method

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -120,19 +120,18 @@ class CacheMiddleware
     {
         return function (RequestInterface $request, array $options) use (&$handler) {
             if (!isset($this->httpMethods[strtoupper($request->getMethod())])) {
-            // No caching for this method allowed
+                // No caching for this method allowed
 
-            
-            return $handler($request, $options)->then(
-                function (ResponseInterface $response) use ($request) {
-                        if (in_array($request->getMethod(), $this->unsafeMethods)) {
-                            // Invalidate cache after a call of non-safe method on the same URI
-                            $response = $this->invalidateCache($request, $response);
+                return $handler($request, $options)->then(
+                    function (ResponseInterface $response) use ($request) {
+                            if (in_array($request->getMethod(), $this->unsafeMethods)) {
+                                // Invalidate cache after a call of non-safe method on the same URI
+                                $response = $this->invalidateCache($request, $response);
+                            }
+
+                            return $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
                         }
-
-                        return $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
-                    }
-                );
+                    );
             }
 
             if ($request->hasHeader(self::HEADER_RE_VALIDATION)) {

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -103,6 +103,19 @@ class CacheMiddleware
         return $this->httpMethods;
     }
 
+    /** 
+     * @param array $unsafeMethods
+     */
+    public function setUnsafeMethods(array $unsafeMethods)
+    {
+        $this->unsafeMethods = $unsafeMethods;
+    }
+
+    public function getUnsafeMethods()
+    {
+        return $this->unsafeMethods;
+    }
+
     /**
      * Will be called at the end of the script.
      */

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -122,16 +122,16 @@ class CacheMiddleware
             if (!isset($this->httpMethods[strtoupper($request->getMethod())])) {
                 // No caching for this method allowed
 
-                return $handler($request, $options)->then(
+                return $handler($request, $options)->then(  
                     function (ResponseInterface $response) use ($request) {
-                            if (in_array($request->getMethod(), $this->unsafeMethods)) {
-                                // Invalidate cache after a call of non-safe method on the same URI
-                                $response = $this->invalidateCache($request, $response);
-                            }
-
-                            return $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
+                        if (in_array($request->getMethod(), $this->unsafeMethods)) {
+                            // Invalidate cache after a call of non-safe method on the same URI
+                            $response = $this->invalidateCache($request, $response);
                         }
-                    );
+
+                        return $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
+                    }
+                );
             }
 
             if ($request->hasHeader(self::HEADER_RE_VALIDATION)) {

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -124,7 +124,7 @@ class CacheMiddleware
             if (!isset($this->httpMethods[strtoupper($request->getMethod())])) {
                 // No caching for this method allowed
 
-                return $handler($request, $options)->then(  
+                return $handler($request, $options)->then(
                     function (ResponseInterface $response) use ($request) {
                         if (!isset($this->safeMethods[$request->getMethod()])) {
                             // Invalidate cache after a call of non-safe method on the same URI

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -50,11 +50,13 @@ class CacheMiddleware
     protected $httpMethods = ['GET' => true];
 
     /** 
-     * List of unsafe methods, 
+     * List of safe methods
+     * 
+     * https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.1
      * 
      * @var array
      */
-    protected $unsafeMethods = ['POST', 'DELETE', 'PUT'];
+    protected $safeMethods = ['GET', 'HEAD', 'OPTIONS', 'TRACE'];
 
     /**
      * @param CacheStrategyInterface|null $cacheStrategy
@@ -103,19 +105,6 @@ class CacheMiddleware
         return $this->httpMethods;
     }
 
-    /** 
-     * @param array $unsafeMethods
-     */
-    public function setUnsafeMethods(array $unsafeMethods)
-    {
-        $this->unsafeMethods = $unsafeMethods;
-    }
-
-    public function getUnsafeMethods()
-    {
-        return $this->unsafeMethods;
-    }
-
     /**
      * Will be called at the end of the script.
      */
@@ -137,7 +126,7 @@ class CacheMiddleware
 
                 return $handler($request, $options)->then(  
                     function (ResponseInterface $response) use ($request) {
-                        if (in_array($request->getMethod(), $this->unsafeMethods)) {
+                        if (!in_array($request->getMethod(), $this->safeMethods)) {
                             // Invalidate cache after a call of non-safe method on the same URI
                             $response = $this->invalidateCache($request, $response);
                         }

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -377,6 +377,10 @@ class CacheMiddleware
     {
         $this->cacheStorage->delete($request);
 
+        foreach (array_diff(array_keys($this->httpMethods), [$request->getMethod()]) as $method) {
+            $this->cacheStorage->delete($request->withMethod($method));
+        }
+
         return $response->withHeader(self::HEADER_INVALIDATION, true);
     }
 }

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -56,7 +56,7 @@ class CacheMiddleware
      * 
      * @var array
      */
-    protected $safeMethods = ['GET', 'HEAD', 'OPTIONS', 'TRACE'];
+    protected $safeMethods = ['GET' => true, 'HEAD' => true, 'OPTIONS' => true, 'TRACE' => true];
 
     /**
      * @param CacheStrategyInterface|null $cacheStrategy
@@ -126,7 +126,7 @@ class CacheMiddleware
 
                 return $handler($request, $options)->then(  
                     function (ResponseInterface $response) use ($request) {
-                        if (!in_array($request->getMethod(), $this->safeMethods)) {
+                        if (!isset($this->safeMethods[$request->getMethod()])) {
                             // Invalidate cache after a call of non-safe method on the same URI
                             $response = $this->invalidateCache($request, $response);
                         }
@@ -386,9 +386,7 @@ class CacheMiddleware
      */
     private function invalidateCache(RequestInterface $request, ResponseInterface $response)
     {
-        $this->cacheStorage->delete($request);
-
-        foreach (array_diff(array_keys($this->httpMethods), [$request->getMethod()]) as $method) {
+        foreach (array_keys($this->httpMethods) as $method) {
             $this->cacheStorage->delete($request->withMethod($method));
         }
 

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -22,7 +22,7 @@ class InvalidateCacheTest extends TestCase
     /**
      * @var CacheMiddleware
      */
-    protected $middelware;
+    protected $middleware;
 
     protected function setUp(): void
     {
@@ -32,11 +32,11 @@ class InvalidateCacheTest extends TestCase
             ]));
         });
 
-        $this->middelware = new CacheMiddleware(new PrivateCacheStrategy(
+        $this->middleware = new CacheMiddleware(new PrivateCacheStrategy(
             new Psr6CacheStorage(new ArrayCachePool()),
         ));
 
-        $stack->push($this->middelware, 'cache');
+        $stack->push($this->middleware, 'cache');
 
         $this->client = new Client(['handler' => $stack]);
     }
@@ -46,7 +46,7 @@ class InvalidateCacheTest extends TestCase
      */
     public function testItInvalidatesForUnsafeHttpMethods($unsafeMethod)
     {
-        $this->middelware->setHttpMethods([
+        $this->middleware->setHttpMethods([
             'GET' => true,
             'HEAD' => true,
         ]);

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -33,7 +33,7 @@ class InvalidateCacheTest extends TestCase
         });
 
         $this->middleware = new CacheMiddleware(new PrivateCacheStrategy(
-            new Psr6CacheStorage(new ArrayCachePool()),
+            new Psr6CacheStorage(new ArrayCachePool())
         ));
 
         $stack->push($this->middleware, 'cache');

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -78,19 +78,6 @@ class InvalidateCacheTest extends TestCase
         $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $response->getHeaderLine('X-Kevinrob-Cache'));
     }
 
-    public function testItAllowsConfiguringUnsafeMethods()
-    {
-        $this->middelware->setUnsafeMethods(['HEAD']);
-
-        $this->client->get('resource');
-
-        $response = $this->client->head('resource');
-        $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
-
-        $response = $this->client->get('resource');
-        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine('X-Kevinrob-Cache'));
-    }
-
     public function unsafeMethods()
     {
         return [
@@ -103,6 +90,7 @@ class InvalidateCacheTest extends TestCase
     public function safemethods()
     {
         return [
+            'get' => ['get'],
             'options' => ['options'],
             'trace' => ['trace'],
             'head' => ['head'],

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -67,7 +67,7 @@ class InvalidateCacheTest extends TestCase
     /**
      * @dataProvider safeMethods
      */
-    public function testItDoesInvalidatesForSafeHttpMethods($safeMethod)
+    public function testItDoesNotInvalidateForSafeHttpMethods($safeMethod)
     {
         $this->client->get('resource');
 

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -78,6 +78,19 @@ class InvalidateCacheTest extends TestCase
         $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $response->getHeaderLine('X-Kevinrob-Cache'));
     }
 
+    public function testItAllowsConfiguringUnsafeMethods()
+    {
+        $this->middelware->setUnsafeMethods(['HEAD']);
+
+        $this->client->get('resource');
+
+        $response = $this->client->head('resource');
+        $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+
+        $response = $this->client->get('resource');
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine('X-Kevinrob-Cache'));
+    }
+
     public function unsafeMethods()
     {
         return [

--- a/tests/InvalidateCacheTest.php
+++ b/tests/InvalidateCacheTest.php
@@ -2,11 +2,14 @@
 
 namespace Kevinrob\GuzzleCache\Tests;
 
+use Cache\Adapter\PHPArray\ArrayCachePool;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Storage\Psr6CacheStorage;
+use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
 use PHPUnit\Framework\TestCase;
 
 class InvalidateCacheTest extends TestCase
@@ -16,15 +19,26 @@ class InvalidateCacheTest extends TestCase
      */
     protected $client;
 
+    /**
+     * @var CacheMiddleware
+     */
+    protected $middelware;
+
     protected function setUp(): void
     {
         // Create default HandlerStack
         $stack = HandlerStack::create(function () {
-            return new FulfilledPromise(new Response());
+            return new FulfilledPromise(new Response(200, [
+                'Cache-Control' => 'private, max-age=300'
+            ]));
         });
 
+        $this->middelware = new CacheMiddleware(new PrivateCacheStrategy(
+            new Psr6CacheStorage(new ArrayCachePool()),
+        ));
+
         // Add this middleware to the top with `push`
-        $stack->push(new CacheMiddleware(), 'cache');
+        $stack->push($this->middelware, 'cache');
 
         // Initialize the client with the handler option
         $this->client = new Client(['handler' => $stack]);
@@ -46,5 +60,24 @@ class InvalidateCacheTest extends TestCase
 
         $response = $this->client->patch('anything');
         $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+    }
+
+    public function testItInvalidatesForAllHttpMethods()
+    {
+        $this->middelware->setHttpMethods([
+            'GET' => true,
+            'POST' => true,
+        ]);
+
+        $this->client->get('anything');
+        $this->client->post('anything');
+
+        $response = $this->client->delete('anything');
+        $this->assertSame('1', $response->getHeaderLine(CacheMiddleware::HEADER_INVALIDATION));
+
+        $response = $this->client->get('anything');
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine('X-Kevinrob-Cache'));
+        $response = $this->client->post('anything');
+        $this->assertEquals(CacheMiddleware::HEADER_CACHE_MISS, $response->getHeaderLine('X-Kevinrob-Cache'));
     }
 }


### PR DESCRIPTION
Fixes #149 

When a request is made with an unsafe method all items for that url should be removed. 

The methods considered safe are the ones listed in the spec https://datatracker.ietf.org/doc/html/rfc7231#section-4.2.1

> Of the request methods defined by this specification, the GET, HEAD, OPTIONS, and TRACE methods are defined to be safe.