### PR TITLE
after calling CacheEntry::__sleep we need to rewind

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "cache/array-adapter": "^0.4 || ^0.5 || ^1.0",
     "illuminate/cache": "^5.0",
     "cache/simple-cache-bridge": "^0.1 || ^1.0",
-    "symfony/phpunit-bridge": "^4.4 || ^5.0"
+    "symfony/phpunit-bridge": "^4.4 || ^5.0",
+    "symfony/cache": "^4.4 || ^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/CacheMiddlewareTest.php
+++ b/tests/CacheMiddlewareTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kevinrob\GuzzleCache\Tests;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use Kevinrob\GuzzleCache\CacheMiddleware as BaseCacheMiddleware;
+use Kevinrob\GuzzleCache\Storage\Psr6CacheStorage;
+use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
+use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+class CacheMiddlewareTest extends TestCase
+{
+    public function testRewindAfterReadingStream()
+    {
+        $stream = Utils::streamFor('seekable stream');
+        $strategy = new PrivateCacheStrategy(
+            new Psr6CacheStorage(
+                new FilesystemAdapter('', -1, sys_get_temp_dir())
+            )
+        );
+        $request = new Request('GET', '/uri');
+        $response = (new Response())->withBody($stream)->withHeader('Cache-Control', 'max-age=3600');
+
+        CacheMiddleware::addToCache(
+            $strategy,
+            $request,
+            $response
+        );
+
+        $this->assertEquals('seekable stream', $response->getBody()->getContents());
+    }
+}
+
+class CacheMiddleware extends BaseCacheMiddleware
+{
+    public static function addToCache(CacheStrategyInterface $cache, RequestInterface $request, ResponseInterface $response, $update = false)
+    {
+        return parent::addToCache($cache, $request, $response, $update);
+    }
+}


### PR DESCRIPTION
After calling CacheEntry::__sleep stream cursor is moved and other middlewares or code cannot read content (without doing a rewind)