### PR TITLE
Fix Laravel Cache storage: set empty string als default value

### DIFF
--- a/src/Storage/LaravelCacheStorage.php
+++ b/src/Storage/LaravelCacheStorage.php
@@ -26,7 +26,7 @@ class LaravelCacheStorage implements CacheStorageInterface
     public function fetch($key)
     {
         try {
-            $cache = unserialize($this->cache->get($key));
+            $cache = unserialize($this->cache->get($key, ''));
             if ($cache instanceof CacheEntry) {
                 return $cache;
             }
@@ -70,7 +70,7 @@ class LaravelCacheStorage implements CacheStorageInterface
     {
         return $this->cache->forget($key);
     }
-    
+
     protected function getLifeTime(CacheEntry $data)
     {
         $version = app()->version();


### PR DESCRIPTION
By default cache return `null` if key is not present. 

The current implementation will cause the following error notice:
`PHP Deprecated:  unserialize(): Passing null to parameter #1 ($data) of type string is deprecated in /var/www/html/vendor/kevinrob/guzzle-cache-middleware/src/Storage/LaravelCacheStorage.php on line 32` 

By setting an empty string as default,`unserialise`will no longer throw the error notice