### PR TITLE
Fix cache entry with key with vary headers isn't deleted

### DIFF
--- a/src/Strategy/PrivateCacheStrategy.php
+++ b/src/Strategy/PrivateCacheStrategy.php
@@ -251,6 +251,13 @@ class PrivateCacheStrategy implements CacheStrategyInterface
      */
     public function delete(RequestInterface $request)
     {
+        $cache = $this->storage->fetch($this->getCacheKey($request));
+
+        if ($cache !==  null && !$cache->getVaryHeaders()->isEmpty()) {
+            $varyHeaders = $cache->getVaryHeaders();
+            $this->storage->delete($this->getCacheKey($request, $varyHeaders));
+        }
         return $this->storage->delete($this->getCacheKey($request));
+
     }
 }


### PR DESCRIPTION
Two cache entries are created when the response has vary headers. But when you call delete, only the entry without the vary headers in the cache key is deleted. 
When you do a new call directly after deletion everything is ok. The cache entry without vary info is created again and returned.  But if you use the Laravel backend, the cache entry with vary info won't be updated. (a  If you repeat the call, the old cache entry with the vary info will be returned and not de fresh cache entry.


To fix this problem, we now delete both entries in the delete method.

 