### PR TITLE
Fix PHP 8.1 deprecation notice

### DIFF
--- a/src/Storage/LaravelCacheStorage.php
+++ b/src/Storage/LaravelCacheStorage.php
@@ -26,7 +26,7 @@ class LaravelCacheStorage implements CacheStorageInterface
     public function fetch($key)
     {
         try {
-            $cache = unserialize($this->cache->get($key));
+            $cache = unserialize($this->cache->get($key) ?? '');
             if ($cache instanceof CacheEntry) {
                 return $cache;
             }


### PR DESCRIPTION
```
unserialize(): Passing null to parameter #1 ($data) of type string is deprecated in vendor\kevinrob\guzzle-cache-middleware\src\Storage\LaravelCacheStorage.php on line 29
```