### PR TITLE
Update composer allow-plugins directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "test": "vendor/bin/phpunit"
-  }
+  },
   "config": {
     "allow-plugins": {
       "kylekatarnls/update-helper": true,

--- a/composer.json
+++ b/composer.json
@@ -49,4 +49,9 @@
   "scripts": {
     "test": "vendor/bin/phpunit"
   }
+  "config": {
+    "allow-plugins": {
+      "kylekatarnls/update-helper": true,
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
   },
   "config": {
     "allow-plugins": {
-      "kylekatarnls/update-helper": true,
+      "kylekatarnls/update-helper": true
     }
   }
 }


### PR DESCRIPTION
```
Error: kylekatarnls/update-helper contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.kylekatarnls/update-helper [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
See https://getcomposer.org/allow-plugins

```