### PR TITLE
Always return stale response if exist on promise rejected callback

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -237,11 +237,9 @@ class CacheMiddleware
                     return static::addToCache($this->cacheStorage, $request, $response, $update);
                 },
                 function ($reason) use ($cacheEntry) {
-                    if ($reason instanceof TransferException) {
-                        $response = static::getStaleResponse($cacheEntry);
-                        if ($response instanceof ResponseInterface) {
-                            return $response;
-                        }
+                    $response = static::getStaleResponse($cacheEntry);
+                    if ($response instanceof ResponseInterface) {
+                        return $response;
                     }
 
                     return new RejectedPromise($reason);


### PR DESCRIPTION
The code check if the rejection is a TransferException before looking for a stale response, but the next handler can reject with anything (e.g. Ganesha reject with its own exception when the circuit is open) and we loose the stale-on-error that we expect.

The proposition here is to just always return stale response if exist on rejected callback.
I could also propose some sort of service to inject to decide if stale response should be looked for if that is more acceptable.

What do you think?

Thanks.