### PR TITLE
Only allow guzzlehttp/promises ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   "require": {
     "php": ">=7.2.0",
     "guzzlehttp/guzzle": "^6.0 || ^7.0",
+    "guzzlehttp/promises": "^1.0",
     "guzzlehttp/psr7": "^1.7.0 || ^2.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
This packages depends on guzzlehttp/promises which gets indirectly pulled in via guzzle. guzzlehttp just had a new release allowing guzzlehttp/promises 2.0 which has various API breaks.

To avoid being installed with guzzlehttp/promises 2.x until this is solved only allow ^1.0.

Fixes #175