### PR TITLE
Update CacheMiddleware.php

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
@@ -110,7 +111,7 @@ class CacheMiddleware
      */
     public function purgeReValidation()
     {
-        \GuzzleHttp\Promise\inspect_all($this->waitingRevalidate);
+        \GuzzleHttp\Promise\Utils::inspect_all($this->waitingRevalidate);
     }
 
     /**


### PR DESCRIPTION
The inspect_all function has been replaced with a Utils::inspect_all function due to "mitigate problems with functions conflicting between global and local copies of the package".