### PR TITLE
The inspect_all function has been changed to Utils::inspectAll.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   "require": {
     "php": ">=7.2.0",
     "guzzlehttp/guzzle": "^6.0 || ^7.0",
+    "guzzlehttp/promises": "^2.0",
     "guzzlehttp/psr7": "^1.7.0 || ^2.0.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=7.2.0",
     "guzzlehttp/guzzle": "^6.0 || ^7.0",
-    "guzzlehttp/promises": "^2.0",
+    "guzzlehttp/promises": "^1.4 || ^2.0",
     "guzzlehttp/psr7": "^1.7.0 || ^2.0.0"
   },
   "require-dev": {

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
@@ -110,7 +111,7 @@ class CacheMiddleware
      */
     public function purgeReValidation()
     {
-        \GuzzleHttp\Promise\inspect_all($this->waitingRevalidate);
+        \GuzzleHttp\Promise\Utils::inspect_all($this->waitingRevalidate);
     }
 
     /**

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Response;
 use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
@@ -111,7 +110,7 @@ class CacheMiddleware
      */
     public function purgeReValidation()
     {
-        \GuzzleHttp\Promise\Utils::inspect_all($this->waitingRevalidate);
+        \GuzzleHttp\Promise\Utils::inspectAll($this->waitingRevalidate);
     }
 
     /**


### PR DESCRIPTION
The change was "to mitigate problems with functions conflicting between global and local copies of the package"...