### PR TITLE
Upgrade to Flysystem v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
-        extensions: mbstring, dom
+        extensions: mbstring, dom, igbinary
 
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require-dev": {
     "phpunit/phpunit": "^8.5.15 || ^9.5",
     "doctrine/cache": "^1.10",
-    "league/flysystem": "^1.0",
+    "league/flysystem": "^2.5",
     "psr/cache": "^1.0",
     "cache/array-adapter": "^0.4 || ^0.5 || ^1.0",
     "illuminate/cache": "^5.0",

--- a/src/Storage/FlysystemStorage.php
+++ b/src/Storage/FlysystemStorage.php
@@ -3,9 +3,9 @@
 namespace Kevinrob\GuzzleCache\Storage;
 
 use Kevinrob\GuzzleCache\CacheEntry;
-use League\Flysystem\AdapterInterface;
 use League\Flysystem\Filesystem;
-use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\FilesystemException;
 
 class FlysystemStorage implements CacheStorageInterface
 {
@@ -15,7 +15,7 @@ class FlysystemStorage implements CacheStorageInterface
      */
     protected $filesystem;
 
-    public function __construct(AdapterInterface $adapter)
+    public function __construct(FilesystemAdapter $adapter)
     {
         $this->filesystem = new Filesystem($adapter);
     }
@@ -25,7 +25,7 @@ class FlysystemStorage implements CacheStorageInterface
      */
     public function fetch($key)
     {
-        if ($this->filesystem->has($key)) {
+        if ($this->filesystem->fileExists($key)) {
             // The file exist, read it!
             $data = @unserialize(
                 $this->filesystem->read($key)
@@ -44,7 +44,7 @@ class FlysystemStorage implements CacheStorageInterface
      */
     public function save($key, CacheEntry $data)
     {
-        return $this->filesystem->put($key, serialize($data));
+        $this->filesystem->write($key, serialize($data));
     }
 
     /**
@@ -53,8 +53,8 @@ class FlysystemStorage implements CacheStorageInterface
     public function delete($key)
     {
         try {
-            return $this->filesystem->delete($key);
-        } catch (FileNotFoundException $ex) {
+            $this->filesystem->delete($key);
+        } catch (FilesystemException $ex) {
             return true;
         }
     }

--- a/tests/PrivateCacheTest.php
+++ b/tests/PrivateCacheTest.php
@@ -18,7 +18,7 @@ use Kevinrob\GuzzleCache\Storage\Psr6CacheStorage;
 use Kevinrob\GuzzleCache\Storage\Psr16CacheStorage;
 use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use PHPUnit\Framework\TestCase;
 
 class PrivateCacheTest extends TestCase
@@ -89,7 +89,7 @@ class PrivateCacheTest extends TestCase
             'doctrine.chaincache' => [ new DoctrineCacheStorage(new ChainCache([new ArrayCache()])) ],
             'doctrine.filesystem' => [ new DoctrineCacheStorage(new FilesystemCache($TMP_DIR)), $TMP_DIR ],
             'doctrine.phpfile' => [ new DoctrineCacheStorage(new PhpFileCache($TMP_DIR)), $TMP_DIR ],
-            'flysystem' => [ new FlysystemStorage(new Local($TMP_DIR)), $TMP_DIR ],
+            'flysystem' => [ new FlysystemStorage(new LocalFilesystemAdapter($TMP_DIR)), $TMP_DIR ],
             'psr6' => [ new Psr6CacheStorage(new ArrayCachePool()) ],
             'psr16' => [ new Psr16CacheStorage(new SimpleCacheBridge(new ArrayCachePool())) ],
             'compressedDoctrineStorage' => [ new CompressedDoctrineCacheStorage(new ArrayCache()) ],

--- a/tests/PublicCacheTest.php
+++ b/tests/PublicCacheTest.php
@@ -22,7 +22,7 @@ use Kevinrob\GuzzleCache\Storage\Psr6CacheStorage;
 use Kevinrob\GuzzleCache\Storage\Psr16CacheStorage;
 use Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage;
 use Kevinrob\GuzzleCache\Strategy\PublicCacheStrategy;
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -100,7 +100,7 @@ class PublicCacheTest extends TestCase
             new DoctrineCacheStorage(new ChainCache([new ArrayCache()])),
             new DoctrineCacheStorage(new FilesystemCache($TMP_DIR)),
             new DoctrineCacheStorage(new PhpFileCache($TMP_DIR)),
-            new FlysystemStorage(new Local($TMP_DIR)),
+            new FlysystemStorage(new LocalFilesystemAdapter($TMP_DIR)),
             new Psr6CacheStorage(new ArrayCachePool()),
             new Psr16CacheStorage(new SimpleCacheBridge(new ArrayCachePool())),
             new CompressedDoctrineCacheStorage(new ArrayCache()),


### PR DESCRIPTION
### Summary: 
Flysystem v3 PR #182 only supports PHP 8. The reason for this PR is to create a compatible release with Flysystem v2, which will support both PHP 7 and PHP 8, and then to merge #182, which will introduce a breaking change.

Also I've added `igbinary` in github workflow as the tests are failing due to this extension. 