### PR TITLE
Reference Middleware and Strategy Headers via `static` keyword instead of `self`

### DIFF
--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -131,14 +131,14 @@ class CacheMiddleware
                             $response = $this->invalidateCache($request, $response);
                         }
 
-                        return $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
+                        return $response->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_MISS);
                     }
                 );
             }
 
-            if ($request->hasHeader(self::HEADER_RE_VALIDATION)) {
+            if ($request->hasHeader(static::HEADER_RE_VALIDATION)) {
                 // It's a re-validation request, so bypass the cache!
-                return $handler($request->withoutHeader(self::HEADER_RE_VALIDATION), $options);
+                return $handler($request->withoutHeader(static::HEADER_RE_VALIDATION), $options);
             }
 
             // Retrieve information from request (Cache-Control)
@@ -162,14 +162,14 @@ class CacheMiddleware
                 ) {
                     // Cache HIT!
                     return new FulfilledPromise(
-                        $cacheEntry->getResponse()->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_HIT)
+                        $cacheEntry->getResponse()->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_HIT)
                     );
                 } elseif ($staleResponse
                     || ($maxStaleCache !== null && $cacheEntry->getStaleAge() <= $maxStaleCache)
                 ) {
                     // Staled cache!
                     return new FulfilledPromise(
-                        $cacheEntry->getResponse()->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_HIT)
+                        $cacheEntry->getResponse()->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_HIT)
                     );
                 } elseif ($cacheEntry->hasValidationInformation() && !$onlyFromCache) {
                     // Re-validation header
@@ -180,7 +180,7 @@ class CacheMiddleware
 
                         return new FulfilledPromise(
                             $cacheEntry->getResponse()
-                                ->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_STALE)
+                                ->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_STALE)
                         );
                     }
                 }
@@ -215,7 +215,7 @@ class CacheMiddleware
                         /** @var ResponseInterface $response */
                         $response = $response
                             ->withStatus($cacheEntry->getResponse()->getStatusCode())
-                            ->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_HIT);
+                            ->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_HIT);
                         $response = $response->withBody($cacheEntry->getResponse()->getBody());
 
                         // Merge headers of the "304 Not Modified" and the cache entry
@@ -224,14 +224,14 @@ class CacheMiddleware
                          * @var string[] $headerValue
                          */
                         foreach ($cacheEntry->getOriginalResponse()->getHeaders() as $headerName => $headerValue) {
-                            if (!$response->hasHeader($headerName) && $headerName !== self::HEADER_CACHE_INFO) {
+                            if (!$response->hasHeader($headerName) && $headerName !== static::HEADER_CACHE_INFO) {
                                 $response = $response->withHeader($headerName, $headerValue);
                             }
                         }
 
                         $update = true;
                     } else {
-                        $response = $response->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_MISS);
+                        $response = $response->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_MISS);
                     }
 
                     return static::addToCache($this->cacheStorage, $request, $response, $update);
@@ -299,7 +299,7 @@ class CacheMiddleware
         // Add the promise for revalidate
         if ($this->client !== null) {
             /** @var RequestInterface $request */
-            $request = $request->withHeader(self::HEADER_RE_VALIDATION, '1');
+            $request = $request->withHeader(static::HEADER_RE_VALIDATION, '1');
             $this->waitingRevalidate[] = $this->client
                 ->sendAsync($request)
                 ->then(function (ResponseInterface $response) use ($request, &$cacheStorage, $cacheEntry) {
@@ -340,7 +340,7 @@ class CacheMiddleware
         // Return staled cache entry if we can
         if ($cacheEntry instanceof CacheEntry && $cacheEntry->serveStaleIfError()) {
             return $cacheEntry->getResponse()
-                ->withHeader(self::HEADER_CACHE_INFO, self::HEADER_CACHE_STALE);
+                ->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_STALE);
         }
 
         return;
@@ -395,6 +395,6 @@ class CacheMiddleware
             $this->cacheStorage->delete($request->withMethod($method));
         }
 
-        return $response->withHeader(self::HEADER_INVALIDATION, true);
+        return $response->withHeader(static::HEADER_INVALIDATION, true);
     }
 }

--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -95,12 +95,12 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
         $response = $response->withoutHeader('Etag')->withoutHeader('Last-Modified');
 
         $ttl = $this->defaultTtl;
-        if ($request->hasHeader(self::HEADER_TTL)) {
-            $ttlHeaderValues = $request->getHeader(self::HEADER_TTL);
+        if ($request->hasHeader(static::HEADER_TTL)) {
+            $ttlHeaderValues = $request->getHeader(static::HEADER_TTL);
             $ttl = (int)reset($ttlHeaderValues);
         }
 
-        return new CacheEntry($request->withoutHeader(self::HEADER_TTL), $response, new \DateTime(sprintf('+%d seconds', $ttl)));
+        return new CacheEntry($request->withoutHeader(static::HEADER_TTL), $response, new \DateTime(sprintf('+%d seconds', $ttl)));
     }
 
     public function fetch(RequestInterface $request)


### PR DESCRIPTION
Classes `CacheMiddleware` & `GreedyCacheStrategy` are shipped with this package with specific header names set via class constant:

https://github.com/Kevinrob/guzzle-cache-middleware/blob/7f258533be4ac2b8c1160d98d2513024937e32c7/src/CacheMiddleware.php#L21-L26

https://github.com/Kevinrob/guzzle-cache-middleware/blob/7f258533be4ac2b8c1160d98d2513024937e32c7/src/Strategy/GreedyCacheStrategy.php#L22

Extending these classes does not currently permit altering those values (unless the functionality altered in this PR are also overridden).

This change updates the references to these class constants to use the `static` keyword as opposed to `self` to take advantage of [PHP's Late Static Bindings](https://www.php.net/manual/en/language.oop5.late-static-bindings.php#language.oop5.late-static-bindings.usage) feature.

That way, custom implementations values are prioritized above the defaults for these headers.

I ran the automated test suite and it still passed for me.