### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
         dependencies:
           - "lowest"
           - "highest"
@@ -29,7 +29,7 @@ jobs:
       with:
         dependency-versions: "${{ matrix.dependencies }}"
       env:
-        COMPOSER_PROCESS_TIMEOUT: 6000 
+        COMPOSER_PROCESS_TIMEOUT: 6000
 
     - name: Run test suite
       run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -14,19 +14,19 @@
   ],
   "require": {
     "php": ">=8.1",
-    "guzzlehttp/guzzle": "^6.0 || ^7.0",
-    "guzzlehttp/promises": "^1.4 || ^2.0",
-    "guzzlehttp/psr7": "^1.7.0 || ^2.0.0"
+    "guzzlehttp/guzzle": "^7.9.2",
+    "guzzlehttp/promises": "^2.0.3",
+    "guzzlehttp/psr7": "^2.7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.15 || ^9.5",
+    "phpunit/phpunit": "^9.6.21",
     "doctrine/cache": "^1.10",
     "league/flysystem": "^2.5",
     "psr/cache": "^1.0",
     "cache/array-adapter": "^0.4 || ^0.5 || ^1.0",
     "illuminate/cache": "^5.0",
     "cache/simple-cache-bridge": "^0.1 || ^1.0",
-    "symfony/phpunit-bridge": "^4.4 || ^5.0",
+    "symfony/phpunit-bridge": "^7.1.4",
     "symfony/cache": "^4.4 || ^5.0"
   },
   "autoload": {

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -57,8 +57,8 @@ class CacheEntry implements \Serializable
         RequestInterface $request,
         ResponseInterface $response,
         \DateTime $staleAt,
-        \DateTime $staleIfErrorTo = null,
-        \DateTime $staleWhileRevalidateTo = null
+        ?\DateTime $staleIfErrorTo = null,
+        ?\DateTime $staleWhileRevalidateTo = null
     ) {
         $this->dateCreated = new \DateTime();
 

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -61,7 +61,7 @@ class CacheMiddleware
     /**
      * @param CacheStrategyInterface|null $cacheStrategy
      */
-    public function __construct(CacheStrategyInterface $cacheStrategy = null)
+    public function __construct(?CacheStrategyInterface $cacheStrategy = null)
     {
         $this->cacheStorage = $cacheStrategy !== null ? $cacheStrategy : new PrivateCacheStrategy();
 
@@ -335,7 +335,7 @@ class CacheMiddleware
      *
      * @return null|ResponseInterface
      */
-    protected static function getStaleResponse(CacheEntry $cacheEntry = null)
+    protected static function getStaleResponse(?CacheEntry $cacheEntry = null)
     {
         // Return staled cache entry if we can
         if ($cacheEntry instanceof CacheEntry && $cacheEntry->serveStaleIfError()) {
@@ -352,7 +352,7 @@ class CacheMiddleware
      *
      * @return RequestInterface
      */
-    protected static function getRequestWithReValidationHeader(RequestInterface $request, CacheEntry $cacheEntry)
+    protected static function getRequestWithReValidationHeader(RequestInterface $request, ?CacheEntry $cacheEntry)
     {
         if ($cacheEntry->getResponse()->hasHeader('Last-Modified')) {
             $request = $request->withHeader(
@@ -377,7 +377,7 @@ class CacheMiddleware
      *
      * @deprecated Use constructor => `new CacheMiddleware()`
      */
-    public static function getMiddleware(CacheStrategyInterface $cacheStorage = null)
+    public static function getMiddleware(?CacheStrategyInterface $cacheStorage = null)
     {
         return new self($cacheStorage);
     }

--- a/src/Strategy/Delegate/DelegatingCacheStrategy.php
+++ b/src/Strategy/Delegate/DelegatingCacheStrategy.php
@@ -22,7 +22,7 @@ class DelegatingCacheStrategy implements CacheStrategyInterface
     /**
      * DelegatingCacheStrategy constructor.
      */
-    public function __construct(CacheStrategyInterface $defaultCacheStrategy = null)
+    public function __construct(?CacheStrategyInterface $defaultCacheStrategy = null)
     {
         $this->defaultCacheStrategy = $defaultCacheStrategy ?: new NullCacheStrategy();
     }

--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -31,14 +31,14 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
      */
     private $varyHeaders;
 
-    public function __construct(CacheStorageInterface $cache = null, $defaultTtl, KeyValueHttpHeader $varyHeaders = null)
+    public function __construct(?CacheStorageInterface $cache = null, $defaultTtl, ?KeyValueHttpHeader $varyHeaders = null)
     {
         $this->defaultTtl = $defaultTtl;
         $this->varyHeaders = $varyHeaders;
         parent::__construct($cache);
     }
 
-    protected function getCacheKey(RequestInterface $request, KeyValueHttpHeader $varyHeaders = null)
+    protected function getCacheKey(RequestInterface $request, ?KeyValueHttpHeader $varyHeaders = null)
     {
         if (null === $varyHeaders || $varyHeaders->isEmpty()) {
             return hash(

--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -31,8 +31,11 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
      */
     private $varyHeaders;
 
-    public function __construct(?CacheStorageInterface $cache = null, $defaultTtl, ?KeyValueHttpHeader $varyHeaders = null)
-    {
+    public function __construct(
+        ?CacheStorageInterface $cache = null,
+        $defaultTtl = 60,
+        ?KeyValueHttpHeader $varyHeaders = null,
+    ) {
         $this->defaultTtl = $defaultTtl;
         $this->varyHeaders = $varyHeaders;
         parent::__construct($cache);

--- a/src/Strategy/PrivateCacheStrategy.php
+++ b/src/Strategy/PrivateCacheStrategy.php
@@ -51,7 +51,7 @@ class PrivateCacheStrategy implements CacheStrategyInterface
         'max-age',
     ];
 
-    public function __construct(CacheStorageInterface $cache = null)
+    public function __construct(?CacheStorageInterface $cache = null)
     {
         $this->storage = $cache !== null ? $cache : new VolatileRuntimeStorage();
     }
@@ -120,7 +120,7 @@ class PrivateCacheStrategy implements CacheStrategyInterface
      *
      * @return string
      */
-    protected function getCacheKey(RequestInterface $request, KeyValueHttpHeader $varyHeaders = null)
+    protected function getCacheKey(RequestInterface $request, ?KeyValueHttpHeader $varyHeaders = null)
     {
         if (!$varyHeaders) {
             return hash('sha256', $request->getMethod().$request->getUri());

--- a/src/Strategy/PublicCacheStrategy.php
+++ b/src/Strategy/PublicCacheStrategy.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class PublicCacheStrategy extends PrivateCacheStrategy
 {
-    public function __construct(CacheStorageInterface $cache = null)
+    public function __construct(?CacheStorageInterface $cache = null)
     {
         parent::__construct($cache);
 


### PR DESCRIPTION
PHP 8.4 is now in release candidate and due for release in about 6 weeks. Features are now sealed.

This pull request:

* Add PHP 8.4 tests in the GitHub Action
* Explicitly declares nullable parameters as nullable

Note: There is still a warning in relation to the `GreedyCacheStrategy` because the second argument (`$defaultTtl`) is required, but the first argument is optional. I'm not sure how you wish to resolve this so I'll defer to a separate issue. Options are to either stop the first argument (`CacheStorageInterface $cache`) from having a _default_ value (but still allowing nullability), or to provide a default of the default ttl.