### PR TITLE
Skip igbinary tests if extension not available

### DIFF
--- a/tests/CacheEntryTest.php
+++ b/tests/CacheEntryTest.php
@@ -83,6 +83,9 @@ class CacheEntryTest extends TestCase
         $this->assertEquals(70, $cacheEntry->getTTL());
     }
 
+    /**
+     * @requires extension igbinary
+     */
     public function testCacheEntryShouldBeSerializableWithIgBinaryWithoutWarning()
     {
         $request = new Request(
@@ -99,16 +102,12 @@ class CacheEntryTest extends TestCase
         );
         $cacheEntry = new CacheEntry($request, $response, $this->makeDateTimeOffset(10));
 
-        if(extension_loaded('igbinary')) {
-            /**
-             * @var CacheEntry $cacheEntryPostDeserialization
-             */
-            $cacheEntryPostDeserialization = igbinary_unserialize(igbinary_serialize($cacheEntry));
-            $this->assertEquals((string)$cacheEntry->getOriginalRequest()->getBody(), (string)$cacheEntryPostDeserialization->getOriginalRequest()->getBody());
-            $this->assertEquals((string)$cacheEntry->getOriginalResponse()->getBody(), (string)$cacheEntryPostDeserialization->getOriginalResponse()->getBody());
-        } else {
-            $this->addWarning('Extension igbinary not loaded, not asserting serialization.');
-        }
+        /**
+         * @var CacheEntry $cacheEntryPostDeserialization
+         */
+        $cacheEntryPostDeserialization = igbinary_unserialize(igbinary_serialize($cacheEntry));
+        $this->assertEquals((string)$cacheEntry->getOriginalRequest()->getBody(), (string)$cacheEntryPostDeserialization->getOriginalRequest()->getBody());
+        $this->assertEquals((string)$cacheEntry->getOriginalResponse()->getBody(), (string)$cacheEntryPostDeserialization->getOriginalResponse()->getBody());
     }
 
     public function testSerializationShouldNotMutateCacheEntry()


### PR DESCRIPTION
The test shoudl be marked as skipped, not throw a warning.