### PR TITLE
Fix binary files being truncated when cached

### DIFF
--- a/src/BodyStore.php
+++ b/src/BodyStore.php
@@ -19,7 +19,7 @@ class BodyStore
     public function __construct(string $body)
     {
         $this->body = $body;
-        $this->toRead = mb_strlen($this->body);
+        $this->toRead = strlen($this->body);
     }
 
     /**
@@ -34,7 +34,7 @@ class BodyStore
 
         $length = min($length, $this->toRead);
 
-        $body = mb_substr(
+        $body = substr(
             $this->body,
             $this->read,
             $length

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -302,7 +302,7 @@ class CacheEntry implements \Serializable
             new PumpStream(
                 new BodyStore($bodyString),
                 [
-                    'size' => mb_strlen($bodyString),
+                    'size' => strlen($bodyString),
                 ]
             )
         );


### PR DESCRIPTION
When the cached Guzzle response is unserialized, the request/response stream is passed through PumpStream. The problem is that PumpStream uses plain `strlen()` to measure data "pumped" into the buffer (which is logically correct IMHO), whereas BodyStore and CacheEntry use `mb_` functions.

This works just fine for "normal" (non-multibyte) text streams but breaks horribly in case of binary data (images etc.). The `mb_strlen()` counts some bytes as multibyte characters, returning smaller size, effectively causing the file being truncated when it's cached...

Fixes #196