### PR TITLE
Use correct class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $stack->push(
 ## Flysystem
 ```php
 [...]
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
 use Kevinrob\GuzzleCache\Storage\FlysystemStorage;
 
@@ -125,7 +125,7 @@ $stack->push(
   new CacheMiddleware(
     new PrivateCacheStrategy(
       new FlysystemStorage(
-        new Local('/path/to/cache')
+        new LocalFilesystemAdapter('/path/to/cache')
       )
     )
   ),


### PR DESCRIPTION
Flysystem changed namespaces as of v2, so the usage example needed an update