### PR TITLE
Fix greedy cache deletion

### DIFF
--- a/src/Strategy/GreedyCacheStrategy.php
+++ b/src/Strategy/GreedyCacheStrategy.php
@@ -117,6 +117,6 @@ class GreedyCacheStrategy extends PrivateCacheStrategy
      */
     public function delete(RequestInterface $request)
     {
-        return $this->storage->delete($this->getCacheKey($request));
+        return $this->storage->delete($this->getCacheKey($request, $this->varyHeaders));
     }
 }


### PR DESCRIPTION
Hello,
First of all, thanks you for this package :smiley: 

The `GreedyCacheStrategy::delete()` wasn't using vary headers to generate the key, but it's used for caching and fetching.
Not using the vary headers here was not deleting from the cache when used with vary headers.

I have added tests for both cases, with and without vary headers.

Let me know if I need to change something.

