### PR TITLE
Fix #82: Fully honor Guzzle 'sink' option on cache hits and revalidations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,8 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="./vendor/autoload.php">
+         bootstrap="./vendor/autoload.php"
+         cacheResultFile="/tmp/.phpunit.result.cache">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">src</directory>

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -3,6 +3,7 @@
 namespace Kevinrob\GuzzleCache;
 
 use GuzzleHttp\Psr7\PumpStream;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -331,7 +332,7 @@ class CacheEntry implements \Serializable
     private static function restoreStreamBody(MessageInterface $message): MessageInterface
     {
         return $message->withBody(
-            \GuzzleHttp\Psr7\Utils::streamFor((string) $message->getBody())
+            Utils::streamFor((string) $message->getBody())
         );
     }
 

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -284,11 +284,6 @@ class CacheMiddleware
         return $response;
     }
 
-    /**
-     * @param ResponseInterface $response
-     * @param array $options
-     * @return ResponseInterface
-     */
     protected function applySink(ResponseInterface $response, array $options): ResponseInterface
     {
         if (isset($options['sink'])) {
@@ -300,19 +295,16 @@ class CacheMiddleware
         return $response;
     }
 
-    /**
-     * @param StreamInterface $body
-     * @param string|resource|StreamInterface $sink
-     * @return StreamInterface
-     */
-    protected function writeToSink(StreamInterface $body, $sink)
+    protected function writeToSink(StreamInterface $body, mixed $sink): StreamInterface
     {
         if (is_string($sink)) {
             $sinkStream = Utils::streamFor(Utils::tryFopen($sink, 'w'));
         } elseif (is_resource($sink)) {
             $sinkStream = Utils::streamFor($sink);
-        } else {
+        } elseif ($sink instanceof StreamInterface) {
             $sinkStream = $sink;
+        } else {
+            throw new \InvalidArgumentException('`sink` must be a resource, string, or StreamInterface');
         }
 
         try {

--- a/src/CacheMiddleware.php
+++ b/src/CacheMiddleware.php
@@ -8,10 +8,12 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Kevinrob\GuzzleCache\Strategy\CacheStrategyInterface;
 use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Class CacheMiddleware.
@@ -152,25 +154,23 @@ class CacheMiddleware
             // If cache => return new FulfilledPromise(...) with response
             $cacheEntry = $this->cacheStorage->fetch($request);
             if ($cacheEntry instanceof CacheEntry) {
-                $body = $cacheEntry->getResponse()->getBody();
-                if ($body->tell() > 0) {
-                    $body->rewind();
-                }
+                $response = $cacheEntry->getResponse();
+                $response->getBody()->rewind();
 
                 if ($cacheEntry->isFresh()
                     && ($minFreshCache === null || $cacheEntry->getStaleAge() + (int)$minFreshCache <= 0)
                 ) {
                     // Cache HIT!
-                    return new FulfilledPromise(
-                        $cacheEntry->getResponse()->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_HIT)
-                    );
+                    $response = $response->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_HIT);
+
+                    return new FulfilledPromise($this->applySink($response, $options));
                 } elseif ($staleResponse
                     || ($maxStaleCache !== null && $cacheEntry->getStaleAge() <= $maxStaleCache)
                 ) {
                     // Staled cache!
-                    return new FulfilledPromise(
-                        $cacheEntry->getResponse()->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_HIT)
-                    );
+                    $response = $response->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_HIT);
+
+                    return new FulfilledPromise($this->applySink($response, $options));
                 } elseif ($cacheEntry->hasValidationInformation() && !$onlyFromCache) {
                     // Re-validation header
                     $request = static::getRequestWithReValidationHeader($request, $cacheEntry);
@@ -178,10 +178,9 @@ class CacheMiddleware
                     if ($cacheEntry->staleWhileValidate()) {
                         static::addReValidationRequest($request, $this->cacheStorage, $cacheEntry);
 
-                        return new FulfilledPromise(
-                            $cacheEntry->getResponse()
-                                ->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_STALE)
-                        );
+                        $response = $response->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_STALE);
+
+                        return new FulfilledPromise($this->applySink($response, $options));
                     }
                 }
             } else {
@@ -199,12 +198,12 @@ class CacheMiddleware
             $promise = $handler($request, $options);
 
             return $promise->then(
-                function (ResponseInterface $response) use ($request, $cacheEntry) {
+                function (ResponseInterface $response) use ($request, $cacheEntry, $options) {
                     // Check if error and looking for a staled content
                     if ($response->getStatusCode() >= 500) {
                         $responseStale = static::getStaleResponse($cacheEntry);
                         if ($responseStale instanceof ResponseInterface) {
-                            return $responseStale;
+                            return $this->applySink($responseStale, $options);
                         }
                     }
 
@@ -229,6 +228,7 @@ class CacheMiddleware
                             }
                         }
 
+                        $response = $this->applySink($response, $options);
                         $update = true;
                     } else {
                         $response = $response->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_MISS);
@@ -236,10 +236,10 @@ class CacheMiddleware
 
                     return static::addToCache($this->cacheStorage, $request, $response, $update);
                 },
-                function ($reason) use ($cacheEntry) {
+                function ($reason) use ($cacheEntry, $options) {
                     $response = static::getStaleResponse($cacheEntry);
                     if ($response instanceof ResponseInterface) {
-                        return $response;
+                        return $this->applySink($response, $options);
                     }
 
                     return new RejectedPromise($reason);
@@ -266,7 +266,7 @@ class CacheMiddleware
         // If the body is not seekable, we have to replace it by a seekable one
         if (!$body->isSeekable()) {
             $response = $response->withBody(
-                \GuzzleHttp\Psr7\Utils::streamFor($body->getContents())
+                Utils::streamFor($body->getContents())
             );
         }
 
@@ -282,6 +282,50 @@ class CacheMiddleware
         }
 
         return $response;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @param array $options
+     * @return ResponseInterface
+     */
+    protected function applySink(ResponseInterface $response, array $options): ResponseInterface
+    {
+        if (isset($options['sink'])) {
+            return $response->withBody(
+                $this->writeToSink($response->getBody(), $options['sink'])
+            );
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param StreamInterface $body
+     * @param string|resource|StreamInterface $sink
+     * @return StreamInterface
+     */
+    protected function writeToSink(StreamInterface $body, $sink)
+    {
+        if (is_string($sink)) {
+            $sinkStream = Utils::streamFor(Utils::tryFopen($sink, 'w'));
+        } elseif (is_resource($sink)) {
+            $sinkStream = Utils::streamFor($sink);
+        } else {
+            $sinkStream = $sink;
+        }
+
+        try {
+            $body->rewind();
+            Utils::copyToStream($body, $sinkStream);
+        } finally {
+            $body->rewind();
+            if ($sinkStream->isSeekable()) {
+                $sinkStream->rewind();
+            }
+        }
+
+        return $sinkStream;
     }
 
     /**
@@ -343,7 +387,7 @@ class CacheMiddleware
                 ->withHeader(static::HEADER_CACHE_INFO, static::HEADER_CACHE_STALE);
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/tests/SinkTest.php
+++ b/tests/SinkTest.php
@@ -129,18 +129,22 @@ class SinkTest extends TestCase
         }
     }
 
-    private function rrmdir($dir) {
-        if (is_dir($dir)) {
-            $objects = scandir($dir);
-            foreach ($objects as $object) {
-                if ($object != "." && $object != "..") {
-                    if (is_dir($dir. DIRECTORY_SEPARATOR .$object) && !is_link($dir."/".$object))
-                        $this->rrmdir($dir. DIRECTORY_SEPARATOR .$object);
-                    else
-                        unlink($dir. DIRECTORY_SEPARATOR .$object);
-                }
-            }
-            rmdir($dir);
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
         }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $fileinfo) {
+            $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+            $todo($fileinfo->getRealPath());
+        }
+
+        rmdir($dir);
     }
 }

--- a/tests/SinkTest.php
+++ b/tests/SinkTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Kevinrob\GuzzleCache\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Storage\FlysystemStorage;
+use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+
+class SinkTest extends TestCase
+{
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSinkWithCacheHit()
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Cache-Control' => 'max-age=60'], 'Hello Sink!')
+        ]);
+        $stack = HandlerStack::create($mock);
+
+        $cacheDir = sys_get_temp_dir() . '/guzzle-cache-' . uniqid();
+        if (!mkdir($cacheDir) && !is_dir($cacheDir)) {
+            throw new \RuntimeException(sprintf('Directory "%s" was not created', $cacheDir));
+        }
+
+        try {
+            $storage = new FlysystemStorage(new LocalFilesystemAdapter($cacheDir));
+            $stack->push(new CacheMiddleware(new PrivateCacheStrategy($storage)), 'cache');
+
+            $client = new Client(['handler' => $stack]);
+
+            // 1. Test with string path
+            $sink1 = tempnam(sys_get_temp_dir(), 'guzzle-sink-1');
+            try {
+                $client->get('http://test.com/sink', ['sink' => $sink1]);
+                $this->assertEquals('Hello Sink!', file_get_contents($sink1));
+
+                $sink2 = tempnam(sys_get_temp_dir(), 'guzzle-sink-2');
+                try {
+                    $response = $client->get('http://test.com/sink', ['sink' => $sink2]);
+                    $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+                    $this->assertEquals('Hello Sink!', file_get_contents($sink2));
+                } finally {
+                    @unlink($sink2);
+                }
+            } finally {
+                @unlink($sink1);
+            }
+
+            // 2. Test with resource
+            $resourceSink = fopen('php://temp', 'r+');
+            try {
+                $response = $client->get('http://test.com/sink', ['sink' => $resourceSink]);
+                $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+                rewind($resourceSink);
+                $this->assertEquals('Hello Sink!', stream_get_contents($resourceSink));
+            } finally {
+                @fclose($resourceSink);
+            }
+
+            // 3. Test with StreamInterface
+            $streamSink = \GuzzleHttp\Psr7\Utils::streamFor(fopen('php://temp', 'r+'));
+            try {
+                $response = $client->get('http://test.com/sink', ['sink' => $streamSink]);
+                $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+                $streamSink->rewind();
+                $this->assertEquals('Hello Sink!', $streamSink->getContents());
+            } finally {
+                $streamSink->close();
+            }
+        } finally {
+            $this->rrmdir($cacheDir);
+        }
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSinkWithRevalidation304()
+    {
+        $mock = new MockHandler([
+            new Response(200, [
+                'Cache-Control' => 'max-age=1',
+                'Etag' => '"abc"'
+            ], 'Hello Revalidation!'),
+            new Response(304, [
+                'Cache-Control' => 'max-age=60',
+                'Etag' => '"abc"'
+            ])
+        ]);
+        $stack = HandlerStack::create($mock);
+
+        try {
+            $storage = new \Kevinrob\GuzzleCache\Storage\VolatileRuntimeStorage();
+            $stack->push(new CacheMiddleware(new PrivateCacheStrategy($storage)), 'cache');
+
+            $client = new Client(['handler' => $stack]);
+
+            // 1. Populate cache
+            $sink1 = tempnam(sys_get_temp_dir(), 'guzzle-sink-reval-1');
+            try {
+                $client->get('http://test.com/reval', ['sink' => $sink1]);
+                $this->assertEquals('Hello Revalidation!', file_get_contents($sink1));
+
+                // 2. Wait for expiration using mock clock
+                $mockClock = new \Symfony\Component\Clock\MockClock(new \DateTimeImmutable('+2 seconds'));
+                \Kevinrob\GuzzleCache\Clock::set($mockClock);
+
+                $sink2 = tempnam(sys_get_temp_dir(), 'guzzle-sink-reval-2');
+                try {
+                    $response = $client->get('http://test.com/reval', ['sink' => $sink2]);
+                    $this->assertEquals(CacheMiddleware::HEADER_CACHE_HIT, $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO));
+                    $this->assertEquals('Hello Revalidation!', file_get_contents($sink2), 'Sink should be populated after 304 revalidation');
+                } finally {
+                    @unlink($sink2);
+                }
+            } finally {
+                @unlink($sink1);
+            }
+        } finally {
+            // No cleanup needed
+        }
+    }
+
+    private function rrmdir($dir) {
+        if (is_dir($dir)) {
+            $objects = scandir($dir);
+            foreach ($objects as $object) {
+                if ($object != "." && $object != "..") {
+                    if (is_dir($dir. DIRECTORY_SEPARATOR .$object) && !is_link($dir."/".$object))
+                        $this->rrmdir($dir. DIRECTORY_SEPARATOR .$object);
+                    else
+                        unlink($dir. DIRECTORY_SEPARATOR .$object);
+                }
+            }
+            rmdir($dir);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes issue #82 by ensuring that Guzzle's `sink` request option is fully respected when a response is served from the cache.

## Changes
- **Sink Support**: Implemented manual body streaming to the provided `sink` destination during Cache HITs, STALE responses, and `304 Not Modified` revalidations.
- **Stream Robustness**: Added checks for stream seekability before rewinding to prevent crashes with non-seekable sinks (like pipes).
**Architecture**: Centralized sink application logic into a protected `applySink` method.
**PHPUnit Maintenance**: Updated `phpunit.xml.dist` to use `/tmp` for the results cache, fixing a permission warning when running tests in Docker.
**Regression Tests**: Added a comprehensive `SinkTest` suite covering file paths, resources, and stream interfaces as sinks.

## Verification
- Verified that files are correctly populated on cache hits.
- Verified that revalidation (304) correctly writes the cached body to the new sink.
- All tests passed on PHP 8.5.