### PR TITLE
Fix Age header value type to string for PSR compliance

### DIFF
--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -138,7 +138,7 @@ class CacheEntry implements \Serializable
     public function getResponse()
     {
         return $this->response
-            ->withHeader('Age', $this->getAge());
+            ->withHeader('Age', (string)$this->getAge());
     }
 
     /**

--- a/src/CacheEntry.php
+++ b/src/CacheEntry.php
@@ -138,7 +138,7 @@ class CacheEntry implements \Serializable
     public function getResponse()
     {
         return $this->response
-            ->withHeader('Age', (string)$this->getAge());
+            ->withHeader('Age', (string) $this->getAge());
     }
 
     /**

--- a/tests/ResponseAgeTest.php
+++ b/tests/ResponseAgeTest.php
@@ -75,6 +75,8 @@ class ResponseAgeTest extends TestCase
         );
 
         // Age header value must be a string to comply with psr/http-message
-        $this->assertIsString($response->getHeaderLine('Age'));
+        $ageHeaderValues = $response->getHeader('Age');
+        $this->assertNotEmpty($ageHeaderValues);
+        $this->assertIsString($ageHeaderValues[0]);
     }
 }

--- a/tests/ResponseAgeTest.php
+++ b/tests/ResponseAgeTest.php
@@ -61,4 +61,20 @@ class ResponseAgeTest extends TestCase
         );
         $this->assertGreaterThanOrEqual(1, $response->getHeaderLine('Age'));
     }
+
+    public function testAgeHeaderValueIsString(): void
+    {
+        $this->client->get('http://test.com/2s');
+
+        $this->mockClock->sleep(1);
+
+        $response = $this->client->get('http://test.com/2s');
+        $this->assertEquals(
+            CacheMiddleware::HEADER_CACHE_HIT,
+            $response->getHeaderLine(CacheMiddleware::HEADER_CACHE_INFO)
+        );
+
+        // Age header value must be a string to comply with psr/http-message
+        $this->assertIsString($response->getHeaderLine('Age'));
+    }
 }


### PR DESCRIPTION
## Problem
`guzzlehttp/psr7` 2.11.0 deprecated passing non-string values to `MessageInterface::withHeader()`,
emitting `E_USER_DEPRECATED` via `trigger_deprecation()`. 

Stacktrace:
    MessageTrait.php: trigger_deprecation('guzzlehttp/psr7', '2.11', 'Passing %s to M...', 'int')
    CacheEntry.php: Response->withHeader('Age', 0)  ← int, not string

## Fix
Cast `getAge()` return value to `string` before passing to `withHeader()`.

## Compatibility
- Fixes psr7 2.11+ deprecation
- Fully backwards compatible with older psr7 versions